### PR TITLE
Fix accessibility level and Add missing documents

### DIFF
--- a/docs/docfx/index.md
+++ b/docs/docfx/index.md
@@ -1,7 +1,7 @@
 # Tizen TV UIControls
 
 The Tizen TV UIControls is a set of helpful extensions to the Xamarin Forms framework for the Samsung TV device.
-The binaries are available via NuGet (package name is "Tizen.TV.UIControls.Forms") with the source available here.
+The binaries are available via NuGet (package name is "Tizen.TV.UIControls") with the source available here.
 
 ## Major Classes
 
@@ -13,4 +13,5 @@ The binaries are available via NuGet (package name is "Tizen.TV.UIControls.Forms
 | [](xref:Tizen.TV.UIControls.Forms.OverlayPage)       | Class that is used to display the video output on a page. |
 | [](xref:Tizen.TV.UIControls.Forms.RecycleItemsView)  | ScrollView that efficiently displays a collection of data using DataTemplate. |
 | [](xref:Tizen.TV.UIControls.Forms.InputEvents)       | Class that helps developers to handle the remote control events that are emitted from TV devices. |
+| [](xref:Tizen.TV.UIControls.Forms.RemoteKeyHandler)  | Class that contains a command and key events that react to remote controller events. |
 

--- a/docs/guides/Overview.md
+++ b/docs/guides/Overview.md
@@ -1,5 +1,5 @@
 # Tizen TV UIControls
-The Tizen TV UIControls is a set of helpful extensions to the Xamarin Forms framework for the Samsung TV device. The binaries are available via NuGet (package name is Tizen.TV.UIControls.Forms) with the source available here.
+The Tizen TV UIControls is a set of helpful extensions to the Xamarin Forms framework for the Samsung TV device. The binaries are available via NuGet (package name is Tizen.TV.UIControls) with the source available here.
 
 ## Screen shot
 <img src=https://user-images.githubusercontent.com/1029155/42200625-34b8332a-7ecf-11e8-9494-5f97cf4c3e60.gif width=250> <img src=https://user-images.githubusercontent.com/1029155/42200629-3742fb16-7ecf-11e8-82ea-dc8dd5fd9619.gif width=250> <img src=https://user-images.githubusercontent.com/1029155/42200631-3b63edcc-7ecf-11e8-8435-31e12c5ed79e.gif width=250> <img src=https://user-images.githubusercontent.com/1029155/42200633-3d5b9396-7ecf-11e8-91c2-72f3d1003360.gif width=250> <img src=https://user-images.githubusercontent.com/1029155/42200637-4685077c-7ecf-11e8-9984-4c68048da265.gif width=250> <img src=https://user-images.githubusercontent.com/1029155/42200638-489afd3c-7ecf-11e8-981d-8f27169ee8c0.gif width=250>

--- a/src/Tizen.TV.UIControls.Forms/FileMediaSource.cs
+++ b/src/Tizen.TV.UIControls.Forms/FileMediaSource.cs
@@ -38,6 +38,10 @@ namespace Tizen.TV.UIControls.Forms
             set { SetValue(FileProperty, value); }
         }
 
+        /// <summary>
+        /// Returns a string representation of `File`.
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
             return $"File: {File}";

--- a/src/Tizen.TV.UIControls.Forms/InputEvents.cs
+++ b/src/Tizen.TV.UIControls.Forms/InputEvents.cs
@@ -26,7 +26,7 @@ namespace Tizen.TV.UIControls.Forms
     /// </summary>
     public sealed class InputEvents
     {
-        public static readonly BindablePropertyKey EventHandlersPropertyKey = BindableProperty.CreateAttachedReadOnly("EventHandlers", typeof(IList<RemoteKeyHandler>), typeof(InputEvents), null,
+        static readonly BindablePropertyKey EventHandlersPropertyKey = BindableProperty.CreateAttachedReadOnly("EventHandlers", typeof(IList<RemoteKeyHandler>), typeof(InputEvents), null,
             defaultValueCreator: bindable =>
             {
                 var collection = new EventHandlerCollection();
@@ -50,8 +50,8 @@ namespace Tizen.TV.UIControls.Forms
         }
 
         /// <summary>
-        /// Returns a collection of the RemoteKeyHandler for the specified view .
-        /// Developers can add or remove RemoteKeyHandlers to this collection. 
+        /// Returns a collection of the `RemoteKeyHandler` for the specified view.
+        /// Developers can add or remove `RemoteKeyHandler`s using this collection.
         /// </summary>
         /// <param name="view">The view to get a collection of the `RemoteKeyHandler`s.</param>
         /// <returns>Returns a collection of the `RemoteKeyHandler`s </returns>

--- a/src/Tizen.TV.UIControls.Forms/RemoteControlKeyEventArgs.cs
+++ b/src/Tizen.TV.UIControls.Forms/RemoteControlKeyEventArgs.cs
@@ -25,7 +25,13 @@ namespace Tizen.TV.UIControls.Forms
     /// </summary>
     public class RemoteControlKeyEventArgs : EventArgs
     {
-        // Constructs a new RemoteControlKeyEventArgs object for a key type and a key name.
+        /// <summary>
+        /// Constructs a new RemoteControlKeyEventArgs object for a key type, key name, and platform key name.
+        /// </summary>
+        /// <param name="sender">The VisualElement that sends the event.</param>
+        /// <param name="keyType">The type of a remote control key.</param>
+        /// <param name="keyName">The name of a remote control key.</param>
+        /// <param name="platformKeyName">The name of a platform key name.</param>
         public RemoteControlKeyEventArgs(VisualElement sender, RemoteControlKeyTypes keyType, RemoteControlKeyNames keyName, string platformKeyName)
         {
             Sender = sender;

--- a/src/Tizen.TV.UIControls.Forms/RemoteKeyHandler.cs
+++ b/src/Tizen.TV.UIControls.Forms/RemoteKeyHandler.cs
@@ -26,9 +26,12 @@ namespace Tizen.TV.UIControls.Forms
     /// </summary>
     public class RemoteKeyHandler : BindableObject
     {
+        /// <summary>
+        /// Backing store for the Command bindable property.
+        /// </summary>
         public static readonly BindableProperty CommandProperty = BindableProperty.Create("Command", typeof(ICommand), typeof(RemoteKeyHandler), null);
 
-        RemoteControlKeyTypes _commandKeyType = RemoteControlKeyTypes.KeyDown | RemoteControlKeyTypes.KeyUp;
+        RemoteControlKeyTypes _acceptedKeyType = RemoteControlKeyTypes.KeyDown | RemoteControlKeyTypes.KeyUp;
 
         /// <summary>
         /// Initializes a new instance of the RemoteKeyHandler class.
@@ -54,7 +57,7 @@ namespace Tizen.TV.UIControls.Forms
         public RemoteKeyHandler(Action<RemoteControlKeyEventArgs> action, RemoteControlKeyTypes keyType)
         {
             Command = new Command<RemoteControlKeyEventArgs>(action);
-            _commandKeyType = keyType;
+            _acceptedKeyType = keyType;
         }
 
         /// <summary>
@@ -66,14 +69,20 @@ namespace Tizen.TV.UIControls.Forms
             set { SetValue(CommandProperty, value); }
         }
 
+        /// <summary>
+        /// Occurs when the remote control key is pressed.
+        /// </summary>
         public event EventHandler<RemoteControlKeyEventArgs> KeyDown;
 
+        /// <summary>
+        /// Occurs when the remote control key is released.
+        /// </summary>
         public event EventHandler<RemoteControlKeyEventArgs> KeyUp;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SendKeyEvent(RemoteControlKeyEventArgs args)
         {
-            if (_commandKeyType.HasFlag(args.KeyType))
+            if (_acceptedKeyType.HasFlag(args.KeyType))
             {
                 ICommand cmd = Command;
                 if (cmd != null && cmd.CanExecute(args))


### PR DESCRIPTION
### Description of Change ###
The accessibility level for `InputEvents.EventHandlersPropertyKey` is changed to private.
Some missing document summaries are added.

### Bugs Fixed ###
N/A


### API Changes ###
Changed:
 - public static readonly BindablePropertyKey EventHandlersPropertyKey => static readonly BindablePropertyKey EventHandlersPropertyKey
('public' keyword is removed.')


### Behavioral Changes ###
N/A
