### PR TITLE
Add new default Entry and Editor Renderer

### DIFF
--- a/sample/Sample/Entry/EntryMainPage.xaml
+++ b/sample/Sample/Entry/EntryMainPage.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Sample.EntryMainPage" Title="Entry">
+    <ContentPage.Content>
+        <ListView ItemsSource="{Binding TestList}" ItemTapped="ItemSelected">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <TextCell Text="{Binding Name}" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </ContentPage.Content>
+</ContentPage>

--- a/sample/Sample/Entry/EntryMainPage.xaml.cs
+++ b/sample/Sample/Entry/EntryMainPage.xaml.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Sample
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class EntryMainPage : ContentPage
+	{
+		public EntryMainPage()
+		{
+			InitializeComponent ();
+            BindingContext = new EntryMainPageModel();
+        }
+
+        async void ItemSelected(object sender, ItemTappedEventArgs args)
+        {
+            EntryTestModel model = (EntryTestModel)args.Item;
+            Page page = (Page)Activator.CreateInstance(model.Page);
+            page.BindingContext = model;
+            await Navigation.PushAsync(page);
+        }
+    }
+}

--- a/sample/Sample/Entry/EntryModels.cs
+++ b/sample/Sample/Entry/EntryModels.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using Tizen.TV.UIControls.Forms;
+
+namespace Sample
+{
+    public class EntryTestModel
+    {
+        public EntryTestModel(string name, Type page)
+        {
+            Name = name;
+            Page = page;
+        }
+
+        public string Name { get; }
+        public Type Page { get; }
+    }
+
+    public class EntryMainPageModel
+    {
+        public List<EntryTestModel> TestList { get; set; }
+
+        public EntryMainPageModel()
+        {
+            TestList = new List<EntryTestModel>()
+            {
+                new EntryTestModel("Entry and Editor test", typeof(TestEntry)),
+            };
+        }
+    }
+}

--- a/sample/Sample/Entry/TestEntry.cs
+++ b/sample/Sample/Entry/TestEntry.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Xamarin.Forms;
+using Tizen.TV.UIControls.Forms;
+
+namespace Sample
+{
+    public class TestEntry : ContentPage
+    {
+        int _clickedTimes = 0;
+        public TestEntry()
+        {
+            Label statusLabel = new Label();
+            var entry = new Entry
+            {
+                Text = "Test Entry"
+            };
+            entry.TextChanged += (s, e) =>
+            {
+                statusLabel.Text = $"Entry TextChanged: {e.NewTextValue}";
+            };
+            entry.Completed += (s, e) =>
+            {
+                statusLabel.Text = $"Entry Completed: {entry.Text}";
+            };
+            var editor = new Editor
+            {
+                Text = "Test Editor"
+            };
+            editor.TextChanged += (s, e) =>
+            {
+                statusLabel.Text = $"Editor TextChanged: {e.NewTextValue}";
+            };
+            editor.Completed += (s, e) =>
+            {
+                statusLabel.Text = $"Editor Completed: {entry.Text}";
+            };
+
+            Content = new StackLayout
+            {
+                Children =
+                {
+                    entry,
+                    editor,
+                    statusLabel,
+                }
+            };
+        }
+    }
+}

--- a/sample/Sample/MainPageModel.cs
+++ b/sample/Sample/MainPageModel.cs
@@ -54,6 +54,11 @@ namespace Sample
                 {
                     Name = "DrawerLayout Test",
                     PageType = typeof(DrawerLayout.DrawerMainPage),
+                },
+                new TestCategory
+                {
+                    Name = "Entry and Editor Test",
+                    PageType = typeof(EntryMainPage),
                 }
             };
         }

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -12,6 +12,9 @@
     <ProjectReference Include="..\..\src\Tizen.TV.UIControls.Forms\Tizen.TV.UIControls.Forms.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Entry\EntryMainPage.xaml.cs">
+      <DependentUpon>EntryMainPage.xaml</DependentUpon>
+    </Compile>
     <Compile Update="MediaPlayer\PlayerMainPage.xaml.cs">
       <DependentUpon>PlayerMainPage.xaml</DependentUpon>
     </Compile>

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Tizen.TV.UIControls.Forms.Renderer;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Tizen;
+
+[assembly: ExportRenderer(typeof(Editor), typeof(TVEditorRenderer))]
+namespace Tizen.TV.UIControls.Forms.Renderer
+{
+    class TVEditorRenderer : EditorRenderer
+    {
+        const string _doneKeyName = "Select";
+        const string _cancelKeyName = "Cancel";
+
+        public TVEditorRenderer() : base()
+        {
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
+        {
+            base.OnElementChanged(e);
+
+            if (Control != null)
+            {
+                InputEvents.GetEventHandlers(Element).Add(new RemoteKeyHandler(new Action<RemoteControlKeyEventArgs>((args) =>
+                {
+                    if (args.PlatformKeyName.Equals(_doneKeyName))
+                    {
+                        Control.SetFocus(false);
+                        Device.BeginInvokeOnMainThread(() =>
+                        {
+                            Element.Text = Control.Text;
+                            Element.SendCompleted();
+                        });
+                    }
+                    else if (args.PlatformKeyName.Equals(_cancelKeyName))
+                    {
+                        Control.HideInputPanel();
+                    }
+                }), RemoteControlKeyTypes.KeyDown));
+            }
+        }
+    }
+}

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
@@ -22,14 +22,10 @@ using Xamarin.Forms.Platform.Tizen;
 [assembly: ExportRenderer(typeof(Editor), typeof(TVEditorRenderer))]
 namespace Tizen.TV.UIControls.Forms.Renderer
 {
-    class TVEditorRenderer : EditorRenderer
+    public class TVEditorRenderer : EditorRenderer
     {
         const string _doneKeyName = "Select";
         const string _cancelKeyName = "Cancel";
-
-        public TVEditorRenderer() : base()
-        {
-        }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
         {

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
@@ -39,7 +39,6 @@ namespace Tizen.TV.UIControls.Forms.Renderer
             {
                 InputEvents.GetEventHandlers(Element).Add(new RemoteKeyHandler(new Action<RemoteControlKeyEventArgs>((args) =>
                 {
-                    Console.WriteLine("@@@@ KEYNAME : " + args.PlatformKeyName);
                     if (args.PlatformKeyName.Equals(_doneKeyName))
                     {
                         Control.SetFocus(false);

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
@@ -22,14 +22,10 @@ using Xamarin.Forms.Platform.Tizen;
 [assembly: ExportRenderer(typeof(Entry), typeof(TVEntryRenderer))]
 namespace Tizen.TV.UIControls.Forms.Renderer
 {
-    class TVEntryRenderer : EntryRenderer
+    public class TVEntryRenderer : EntryRenderer
     {
         const string _doneKeyName = "Select";
         const string _cancelKeyName = "Cancel";
-
-        public TVEntryRenderer() : base()
-        {
-        }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
         {

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Tizen.TV.UIControls.Forms.Renderer;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Tizen;
+
+[assembly: ExportRenderer(typeof(Entry), typeof(TVEntryRenderer))]
+namespace Tizen.TV.UIControls.Forms.Renderer
+{
+    class TVEntryRenderer : EntryRenderer
+    {
+        const string _doneKeyName = "Select";
+        const string _cancelKeyName = "Cancel";
+
+        public TVEntryRenderer() : base()
+        {
+        }
+
+        protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
+        {
+            base.OnElementChanged(e);
+
+            if (Control != null)
+            {
+                InputEvents.GetEventHandlers(Element).Add(new RemoteKeyHandler(new Action<RemoteControlKeyEventArgs>((args) =>
+                {
+                    Console.WriteLine("@@@@ KEYNAME : " + args.PlatformKeyName);
+                    if (args.PlatformKeyName.Equals(_doneKeyName))
+                    {
+                        Control.SetFocus(false);
+                        Device.BeginInvokeOnMainThread(() =>
+                        {
+                            Element.Text = Control.Text;
+                            Element.SendCompleted();
+                        });
+                    }
+                    else if (args.PlatformKeyName.Equals(_cancelKeyName))
+                    {
+                        Control.HideInputPanel();
+                    }
+                }), RemoteControlKeyTypes.KeyDown));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Provide default renderers for Entry and Editor to cover the problem of input panel.
The renderers handle the input panel to show and hide.

### Bugs Fixed ###
- Cover the issue of not hiding input panel.

### API Changes ###
- None

### Behavioral Changes ###
The input panel hides when 'Done' or 'Cancel' key is clicked.
