### PR TITLE
Update Xamarin.Forms version to 3.2.0

### DIFF
--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -6,7 +6,7 @@
 
   <!-- Include Nuget Package for Xamarin building -->
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.583944" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.871581" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Tizen.TV.UIControls.Forms\Tizen.TV.UIControls.Forms.csproj" />

--- a/src/Tizen.TV.UIControls.Forms/Tizen.TV.UIControls.Forms.csproj
+++ b/src/Tizen.TV.UIControls.Forms/Tizen.TV.UIControls.Forms.csproj
@@ -24,7 +24,7 @@
     <EmbeddedResource Update="EmbeddingControls.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <PackageReference Include="Xamarin.Forms" Version="3.1.0.583944" />
+    <PackageReference Include="Xamarin.Forms" Version="3.2.0.871581" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'tizen40' ">


### PR DESCRIPTION
### Description of Change ###
Update the Xamarin.Forms package version to 3.2.0 Service Release 1 (3.2.0.871581). Update test apps as well.

### Bugs Fixed ###
None

### API Changes ###
None

### Behavioral Changes ###
None
