### PR TITLE
[InputEvents] Considering modal page when event is delivered

### DIFF
--- a/src/Tizen.TV.UIControls.Forms/Renderer/AccessKeyEffect.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/AccessKeyEffect.cs
@@ -19,6 +19,7 @@ using ElmSharp;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
 using Tizen.TV.UIControls.Forms.Renderer;
+using System.Linq;
 
 [assembly: ExportEffect(typeof(AccessKeyEffect), "AccessKeyEffect")]
 namespace Tizen.TV.UIControls.Forms.Renderer
@@ -73,6 +74,9 @@ namespace Tizen.TV.UIControls.Forms.Renderer
 
         bool IsOnCurrentPage(Page currentPage, Page targetPage)
         {
+            if (currentPage.Navigation.ModalStack.Count > 0)
+                currentPage = currentPage.Navigation.ModalStack.LastOrDefault();
+
             if (currentPage == targetPage)
                 return true;
 

--- a/src/Tizen.TV.UIControls.Forms/Renderer/RemoteKeyEventEffect.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/RemoteKeyEventEffect.cs
@@ -19,6 +19,7 @@ using ElmSharp;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
 using Tizen.TV.UIControls.Forms.Renderer;
+using System.Linq;
 
 [assembly: ResolutionGroupName("TizenTVUIControl")]
 [assembly: ExportEffect(typeof(RemoteKeyEventEffect), "RemoteKeyEventEffect")]
@@ -107,6 +108,9 @@ namespace Tizen.TV.UIControls.Forms.Renderer
 
         bool IsOnCurrentPage(Page currentPage, Page targetPage)
         {
+            if (currentPage.Navigation.ModalStack.Count > 0)
+                currentPage = currentPage.Navigation.ModalStack.LastOrDefault();
+
             if (currentPage == targetPage)
                 return true;
 


### PR DESCRIPTION
### Description of Change ###
- The key event was not delivered properly when the `Modal Page` is pushed.
- This PR fixes the logic to find the current page by considering modal stack.

### Bugs Fixed ###
- https://github.com/Samsung/Tizen.TV.UIControls/issues/38

### API Changes ###
- N/A

### Behavioral Changes ###
- N/A

