### PR TITLE
Fix OverlayMediaView resize issue

### DIFF
--- a/src/Tizen.TV.UIControls.Forms/Renderer/MediaPlayerImpl.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/MediaPlayerImpl.cs
@@ -307,13 +307,9 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                     var renderer = Platform.GetRenderer(TargetView);
                     if (renderer is OverlayViewRenderer)
                     {
-                        var parentArea = renderer.NativeView.Geometry;
-                        if (parentArea.Width == 0 || parentArea.Height == 0)
-                        {
-                            await Task.Delay(1);
-                            parentArea = renderer.NativeView.Geometry;
-                        }
-                        bound = parentArea;
+                        // need to convert absolute coordinate from relative coordinate
+                        await Task.Delay(1);
+                        bound = renderer.NativeView.Geometry;
                     }
                     _player.DisplaySettings.SetRoi(bound.ToMultimedia());
                 }


### PR DESCRIPTION
### Description of Change ###
OverlayMediaView size changing was not apply to overlay area, because it used a area of View, but view size was update after render loop so I fix it to apply after render

### Bugs Fixed ###
- fix: https://github.com/Samsung/Tizen.TV.UIControls/issues/56


### API Changes ###
None

### Behavioral Changes ###
None
