### PR TITLE
Add FocusFrame

### DIFF
--- a/docs/guides/FocusFrame.md
+++ b/docs/guides/FocusFrame.md
@@ -1,0 +1,82 @@
+
+# FocusFrame
+`FocusFrame` helps developers to decorate a focused view. it contain a view to represent and if it got a focus, backgroud color of `FocusFrame` is changed
+
+## How to use it
+ Set a `Content` property using a view that a target of focus, set `FocusedColor` to want. (default color is Orange)
+
+### xaml
+``` xml
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             x:Class="Sample.FocusFrameTest"
+             x:Name="rootPage">
+    <ContentPage.Content>
+        <StackLayout>
+            <tv:FocusFrame FocusedColor="Blue">
+                <Button Text="Button1"/>
+            </tv:FocusFrame>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>
+```
+
+### C#
+``` C#
+public class FocusFrameTest : ContentPage
+{
+    public FocusFrameTest()
+    {
+        Button button1 = new Button { Text = "Button1" };
+        FocusFrame focusFrame = new FocusFrame
+        {
+            FocusedColor = Color.Blue,
+            Content = Button1
+        };
+
+        Content = new StackLayout
+        {
+            Children =
+            {
+                focusFrame,
+            }
+        };
+    }
+}
+```
+
+
+## How to override the focus effect
+ Overriding `OnContentFocused` method and implements decorating code
+``` C#
+public class MyFocusFrame : FocusFrame
+{
+    protected override void OnContentFocused(bool isFocused)
+    {
+        if (isFocused)
+        {
+            Content.ScaleTo(1.5);
+        }
+        else
+        {
+            Content.ScaleTo(1);
+        }
+    }
+}
+```
+``` xml
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             xmlns:local="clr-namespace:Sample.Focus"
+             x:Class="Sample.FocusFrameTest">
+    <ContentPage.Content>
+        <StackLayout>
+            <local:MyFocusFrame>
+                <Button Text="Button1"/>
+            </tv:MyFocusFrame>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>
+```

--- a/docs/guides/toc.md
+++ b/docs/guides/toc.md
@@ -8,5 +8,7 @@
 ## [Introduction](InputEvents.md)
 #DrawerLayout
 ## [Introduction](DrawerLayout.md)
+#FocusFrame
+## [Introduction](FocusFrame.md)
 #Troubleshooter
 ## [Solved Problem](Troubleshooter.md)

--- a/sample/Sample/Focus/FocusFrameTest.xaml
+++ b/sample/Sample/Focus/FocusFrameTest.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             xmlns:local="clr-namespace:Sample.Focus"
              Title="Focus navigation"
              x:Class="Sample.Focus.FocusFrameTest">
     <ContentPage.Content>
@@ -33,9 +34,9 @@
             <tv:FocusFrame FocusedColor="Red" Grid.Row="2" Grid.Column="1">
                 <Button Text="2"/>
             </tv:FocusFrame>
-            <tv:FocusFrame Grid.Row="2" Grid.Column="2">
+            <local:MyFocusFrame Grid.Row="2" Grid.Column="2">
                 <Button Text="3"/>
-            </tv:FocusFrame>
+            </local:MyFocusFrame>
             <tv:FocusFrame Grid.Row="2" Grid.Column="3">
                 <Button Text="4"/>
             </tv:FocusFrame>

--- a/sample/Sample/Focus/FocusFrameTest.xaml
+++ b/sample/Sample/Focus/FocusFrameTest.xaml
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             Title="Focus navigation"
+             x:Class="Sample.Focus.FocusFrameTest">
+    <ContentPage.Content>
+        <Grid RowDefinitions="100, 100, 100, *"
+              ColumnDefinitions="*, *, *, *">
+            <tv:FocusFrame Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
+                <Entry Placeholder="Entry1" />
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2">
+                <Entry Placeholder="Entry2" />
+            </tv:FocusFrame>
+
+            <tv:FocusFrame Grid.Row="1" Grid.Column="0">
+                <CheckBox/>
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="1" Grid.Column="1">
+                <CheckBox/>
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="1" Grid.Column="2">
+                <CheckBox/>
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="1" Grid.Column="3">
+                <CheckBox/>
+            </tv:FocusFrame>
+
+            <tv:FocusFrame Grid.Row="2" Grid.Column="0">
+                <Button Text="1"/>
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="2" Grid.Column="1">
+                <Button Text="2"/>
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="2" Grid.Column="2">
+                <Button Text="3"/>
+            </tv:FocusFrame>
+            <tv:FocusFrame Grid.Row="2" Grid.Column="3">
+                <Button Text="4"/>
+            </tv:FocusFrame>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/sample/Sample/Focus/FocusFrameTest.xaml
+++ b/sample/Sample/Focus/FocusFrameTest.xaml
@@ -17,7 +17,7 @@
             <tv:FocusFrame Grid.Row="1" Grid.Column="0">
                 <CheckBox/>
             </tv:FocusFrame>
-            <tv:FocusFrame Grid.Row="1" Grid.Column="1">
+            <tv:FocusFrame FocusedColor="Yellow" Grid.Row="1" Grid.Column="1">
                 <CheckBox/>
             </tv:FocusFrame>
             <tv:FocusFrame Grid.Row="1" Grid.Column="2">
@@ -30,7 +30,7 @@
             <tv:FocusFrame Grid.Row="2" Grid.Column="0">
                 <Button Text="1"/>
             </tv:FocusFrame>
-            <tv:FocusFrame Grid.Row="2" Grid.Column="1">
+            <tv:FocusFrame FocusedColor="Red" Grid.Row="2" Grid.Column="1">
                 <Button Text="2"/>
             </tv:FocusFrame>
             <tv:FocusFrame Grid.Row="2" Grid.Column="2">

--- a/sample/Sample/Focus/FocusFrameTest.xaml.cs
+++ b/sample/Sample/Focus/FocusFrameTest.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Sample.Focus
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class FocusFrameTest : ContentPage
+    {
+        public FocusFrameTest()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/sample/Sample/Focus/FocusFrameTest.xaml.cs
+++ b/sample/Sample/Focus/FocusFrameTest.xaml.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿using Tizen.TV.UIControls.Forms;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -15,6 +10,21 @@ namespace Sample.Focus
         public FocusFrameTest()
         {
             InitializeComponent();
+        }
+    }
+
+    public class MyFocusFrame : FocusFrame
+    {
+        protected override void OnContentFocused(bool isFocused)
+        {
+            if (isFocused)
+            {
+                Content.ScaleTo(1.5);
+            }
+            else
+            {
+                Content.ScaleTo(1);
+            }
         }
     }
 }

--- a/sample/Sample/Focus/FocusTestModel.cs
+++ b/sample/Sample/Focus/FocusTestModel.cs
@@ -52,6 +52,11 @@ namespace Sample.Focus
                     Name = "Focus Test3",
                     PageType = typeof(FocusTest3)
                 },
+                new TestModel
+                {
+                    Name = "Focus Frame",
+                    PageType = typeof(FocusFrameTest)
+                }
             };
         }
     }

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -1,13 +1,38 @@
-﻿using System.Runtime.CompilerServices;
+﻿/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
 using Xamarin.Forms;
 
 namespace Tizen.TV.UIControls.Forms
 {
+    /// <summary>
+    /// It is a container to decorate focused state
+    /// </summary>
     public class FocusFrame : Frame
     {
-
+        /// <summary>
+        /// Identifies the FocusedColor bindable property.
+        /// </summary>
         public static readonly BindableProperty FocusedColorProperty = BindableProperty.Create(nameof(FocusedColor), typeof(Color), typeof(FocusFrame), Color.Orange);
 
+
+        /// <summary>
+        /// Creates and initializes a new instance of the FocusFrame class.
+        /// </summary>
         public FocusFrame()
         {
             Padding = 10;
@@ -15,6 +40,9 @@ namespace Tizen.TV.UIControls.Forms
             HasShadow = false;
         }
 
+        /// <summary>
+        /// Gets or sets a value that represents FocusedColor, it used for decorating focused state on content
+        /// </summary>
         public Color FocusedColor
         {
             get => (Color)GetValue(FocusedColorProperty);
@@ -47,6 +75,11 @@ namespace Tizen.TV.UIControls.Forms
             }
         }
 
+        /// <summary>
+        /// This method was called when content's focused state was changed.
+        /// To change behavior of decorating, overriding this method
+        /// </summary>
+        /// <param name="isFocused">This parameter indicates whether the content is focused.</param>
         protected virtual void OnContentFocused(bool isFocused)
         {
             BackgroundColor = isFocused ? FocusedColor : Color.Transparent;

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.CompilerServices;
+using Xamarin.Forms;
+
+namespace Tizen.TV.UIControls.Forms
+{
+    public class FocusFrame : Frame
+    {
+        public FocusFrame()
+        {
+            Padding = 10;
+            BorderColor = Color.Transparent;
+            HasShadow = false;
+        }
+
+        protected override void OnPropertyChanging([CallerMemberName] string propertyName = null)
+        {
+            base.OnPropertyChanging(propertyName);
+            if (propertyName == nameof(Content))
+            {
+                if (Content != null)
+                {
+                    Content.Focused -= OnContentFocused;
+                    Content.Unfocused -= OnContentFocused;
+                }
+            }
+        }
+
+        protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            base.OnPropertyChanged(propertyName);
+            if (propertyName == nameof(Content))
+            {
+                if (Content != null)
+                {
+                    Content.Focused += OnContentFocused;
+                    Content.Unfocused += OnContentFocused;
+                }
+            }
+        }
+
+        protected virtual void OnContentFocused(bool isFocused)
+        {
+            BackgroundColor = isFocused ? Color.Orange : Color.Transparent;
+        }
+
+        void OnContentFocused(object sender, FocusEventArgs e)
+        {
+            OnContentFocused(e.IsFocused);
+        }
+    }
+}

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -5,11 +5,20 @@ namespace Tizen.TV.UIControls.Forms
 {
     public class FocusFrame : Frame
     {
+
+        public static readonly BindableProperty FocusedColorProperty = BindableProperty.Create(nameof(FocusedColor), typeof(Color), typeof(FocusFrame), Color.Orange);
+
         public FocusFrame()
         {
             Padding = 10;
             BorderColor = Color.Transparent;
             HasShadow = false;
+        }
+
+        public Color FocusedColor
+        {
+            get => (Color)GetValue(FocusedColorProperty);
+            set => SetValue(FocusedColorProperty, value);
         }
 
         protected override void OnPropertyChanging([CallerMemberName] string propertyName = null)
@@ -40,7 +49,7 @@ namespace Tizen.TV.UIControls.Forms
 
         protected virtual void OnContentFocused(bool isFocused)
         {
-            BackgroundColor = isFocused ? Color.Orange : Color.Transparent;
+            BackgroundColor = isFocused ? FocusedColor : Color.Transparent;
         }
 
         void OnContentFocused(object sender, FocusEventArgs e)

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
@@ -49,6 +49,12 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                         Control.HideInputPanel();
                     }
                 }), RemoteControlKeyTypes.KeyDown));
+
+                if (Control is Xamarin.Forms.Platform.Tizen.Native.Entry nentry)
+                {
+                    nentry.EntryLayoutFocused += OnFocused;
+                    nentry.EntryLayoutUnfocused += OnUnfocused;
+                }
             }
         }
     }

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEditorRenderer.cs
@@ -37,7 +37,7 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                 {
                     if (args.PlatformKeyName.Equals(_doneKeyName))
                     {
-                        Control.SetFocus(false);
+                        FocusSearch(true)?.SetFocus(true);
                         Device.BeginInvokeOnMainThread(() =>
                         {
                             Element.Text = Control.Text;

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
@@ -15,7 +15,6 @@
  */
 
 using System;
-using Tizen.Network.Nfc;
 using Tizen.TV.UIControls.Forms.Renderer;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
@@ -38,7 +38,7 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                 {
                     if (args.PlatformKeyName.Equals(_doneKeyName))
                     {
-                        Element.Unfocus();
+                        FocusSearch(true)?.SetFocus(true);
                         Device.BeginInvokeOnMainThread(() =>
                         {
                             Element.Text = Control.Text;

--- a/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/TVEntryRenderer.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using Tizen.Network.Nfc;
 using Tizen.TV.UIControls.Forms.Renderer;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
@@ -37,7 +38,7 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                 {
                     if (args.PlatformKeyName.Equals(_doneKeyName))
                     {
-                        Control.SetFocus(false);
+                        Element.Unfocus();
                         Device.BeginInvokeOnMainThread(() =>
                         {
                             Element.Text = Control.Text;
@@ -49,6 +50,12 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                         Control.HideInputPanel();
                     }
                 }), RemoteControlKeyTypes.KeyDown));
+
+                if (Control is Xamarin.Forms.Platform.Tizen.Native.Entry nentry)
+                {
+                    nentry.EntryLayoutFocused += OnFocused;
+                    nentry.EntryLayoutUnfocused += OnUnfocused;
+                }
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###
 This PR introduce a new View to decorate focused state.
 Some UI component does not change its looks when it was focused, So user hard to recognize focused state.
 App developer need to change looks when view was focused, `FocusFrame` make it easy

### How to use
``` xaml
<tv:FocusFrame>
    <Entry Placeholder="Entry1" />
</tv:FocusFrame>
<tv:FocusFrame FocusedColor="Red">
    <Button />
</tv:FocusFrame>
```

### Bugs Fixed ###

### API Changes ###
List all API changes here 
(or just put None when your changes are only bug fix, behavior change, add/fix testcase, add/fix sample), example:

Added:
 - class FocusFrame : Frame
 
### Behavioral Changes ###
| . | Changes |
|-|-|
|Before|![focusframe-before](https://user-images.githubusercontent.com/1029155/95173777-19ba8180-07f4-11eb-9f51-5f79ca969c34.gif)|
|After|![focuseframe-after](https://user-images.githubusercontent.com/1029155/95173825-2c34bb00-07f4-11eb-8efd-348c89005e2d.gif)|
