### PR TITLE
Add ContentButton control

### DIFF
--- a/docs/guides/ContentButton.md
+++ b/docs/guides/ContentButton.md
@@ -1,0 +1,71 @@
+
+# ContentButton
+`ContentButton` is a type of Xamarin.Forms.ContentView that contains a single child element (called Content) and is typically used for custom, reusable controls. Also, as its name implies, ContentButton is designed to be used like a Button that implements `Xamarin.Forms.IButtonController`.
+
+## How to customize the button using `ContentButton`?
+
+`ContentButton` provides the view to show and the states(Clicked, Pressed and Released) of the button. You can customize the button through changing the view according to the state.
+The following example shows the CustomButton composed of a combination of Images that define the icon, background, and border of a button.
+To show a border, this example has set an outlined image with blending color as a Content, and the background color of the button will change to gray when the button is pressed for click-effect.
+
+For more information, see the following links:
+
+- [ContentButton API reference](https://samsung.github.io/Tizen.TV.UIControls/api/Tizen.TV.UIControls.Forms.ContentButton.html)
+
+## Create ContentButton
+
+**C# file**
+
+```cs
+public class ContentButtonTest : ContentPage
+{
+    public ContentButtonTest()
+    {
+        ContentButton button = new ContentButton 
+        { 
+            Content = new Label { Text = "Text Button" }
+        };
+
+        Content = new StackLayout
+        {
+            Children =
+            {
+                button,
+            }
+        };
+    }
+}
+```
+
+**XAML file**
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             Title="ContentButton Test"
+             x:Class="Sample.ContentButton.ContentButtonTest">
+    <ContentPage.Content>
+        <StackLayout HorizontalOptions="Center">
+            <tv:ContentButton Clicked="ContentButton_Clicked">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="Transparent"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Focused">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="Orange"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+                <Label FontSize="Header" x:Name="_label" Text="Text Button" />
+            </tv:ContentButton>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>
+```

--- a/docs/guides/toc.md
+++ b/docs/guides/toc.md
@@ -10,5 +10,7 @@
 ## [Introduction](DrawerLayout.md)
 #FocusFrame
 ## [Introduction](FocusFrame.md)
+#ContentButton
+## [Introduction](ContentButton.md)
 #Troubleshooter
 ## [Solved Problem](Troubleshooter.md)

--- a/sample/Sample/ContentButton/ContentButtonTest.xaml
+++ b/sample/Sample/ContentButton/ContentButtonTest.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             Title="ContentButton Test"
+             x:Class="Sample.ContentButton.ContentButtonTest">
+    <ContentPage.Content>
+        <StackLayout HorizontalOptions="Center">
+            <tv:ContentButton Clicked="ContentButton_Clicked">
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup x:Name="CommonStates">
+                        <VisualState x:Name="Normal">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="Transparent"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="Focused">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="Orange"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+                <Label FontSize="Header" x:Name="_label" Text="Text Button" />
+            </tv:ContentButton>
+            <tv:FocusFrame>
+                <tv:ContentButton Clicked="ContentButton_Clicked_1" HeightRequest="300" WidthRequest="300">
+                    <Image x:Name="_image" Source="albumarts/1984, Van Halen.jpg"/>
+                </tv:ContentButton>
+            </tv:FocusFrame>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/sample/Sample/ContentButton/ContentButtonTest.xaml.cs
+++ b/sample/Sample/ContentButton/ContentButtonTest.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Sample.ContentButton
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class ContentButtonTest : ContentPage
+    {
+        public ContentButtonTest()
+        {
+            InitializeComponent();
+        }
+
+        int count = 0;
+        private void ContentButton_Clicked(object sender, EventArgs e)
+        {
+            _label.Text = $"Text button ({++count})";
+        }
+
+        int imgIndex = 0;
+        private void ContentButton_Clicked_1(object sender, EventArgs e)
+        {
+            string[] imgs =
+            {
+                "albumarts/1984, Van Halen.jpg",
+                "albumarts/I'm in Love (I Wanna Do It), Alex Gaudino.jpg",
+                "albumarts/1989, Taylor Swift.jpg"
+            };
+            _image.Source = imgs[++imgIndex % 3];
+        }
+    }
+}

--- a/sample/Sample/MainPageModel.cs
+++ b/sample/Sample/MainPageModel.cs
@@ -62,6 +62,11 @@ namespace Sample
                 {
                     Name = "Custom Focus Test",
                     PageType = typeof(Focus.FocusMainPage),
+                },
+                new TestCategory
+                {
+                    Name = "ContentButton Test",
+                    PageType = typeof(ContentButton.ContentButtonTest)
                 }
             };
         }

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -26,6 +26,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="ContentButton\ContentButtonTest.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="DrawerLayout\DrawerMainPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/Tizen.TV.UIControls.Forms/ContentButton.cs
+++ b/src/Tizen.TV.UIControls.Forms/ContentButton.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.ComponentModel;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace Tizen.TV.UIControls.Forms
+{
+    /// <summary>
+    /// The ContentButton is a Button, which allows you to customize the View to be displayed.
+    /// </summary>
+    public class ContentButton : ContentView, IButtonController
+    {
+        /// <summary>
+        /// BindableProperty. Identifies the Command bindable property.
+        /// </summary>
+        public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(ContentButton), null, 
+            propertyChanging: OnCommandChanging, propertyChanged: OnCommandChanged);
+
+        /// <summary>
+        /// BindableProperty. Identifies the CommandParameter bindable property.
+        /// </summary>
+        public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(ContentButton), null, 
+            propertyChanged: (bindable, oldvalue, newvalue) => CommandCanExcuteChanged(bindable, EventArgs.Empty));
+
+        /// <summary>
+        /// Gets or sets command that is executed when the button is clicked.
+        /// </summary>
+        public ICommand Command
+        {
+            get => (ICommand)GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets command paramter that is executed when the button is clicked.
+        /// </summary>
+        public object CommandParameter
+        {
+            get => GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
+        }
+
+        /// <summary>
+        /// Occurs when the button is clicked.
+        /// </summary>
+        public event EventHandler Clicked;
+
+        /// <summary>
+        /// Occurs when the button is pressed.
+        /// </summary>
+        public event EventHandler Pressed;
+
+        /// <summary>
+        /// Occurs when the button is released.
+        /// </summary>
+        public event EventHandler Released;
+
+        bool IsEnabledCore
+        {
+            set => SetValueCore(IsEnabledProperty, value);
+        }
+
+        /// <summary>
+        /// For internal use.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SendClicked()
+        {
+            if (IsEnabled)
+            {
+                Command?.Execute(CommandParameter);
+                Clicked?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// For internal use.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SendPressed()
+        {
+            if (IsEnabled)
+            {
+                Pressed?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// For internal use.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SendReleased()
+        {
+            if (IsEnabled)
+            {
+                Released?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        protected override void OnBindingContextChanged()
+        {
+            base.OnBindingContextChanged();
+
+            View content = Content;
+            if (content != null)
+            {
+                SetInheritedBindingContext(content, BindingContext);
+            }
+        }
+
+        static void OnCommandChanged(BindableObject bindable, object oldCommand, object newCommand)
+        {
+            ContentButton button = (ContentButton)bindable;
+            if (newCommand is ICommand command)
+            {
+                command.CanExecuteChanged += button.OnCommandCanExecuteChanged;
+            }
+            CommandChanged(button);
+        }
+
+        static void CommandChanged(ContentButton button)
+        {
+            if (button.Command != null)
+            {
+                CommandCanExcuteChanged(button, EventArgs.Empty);
+            }
+            else
+            {
+                button.IsEnabledCore = true;
+            }
+        }
+
+        static void OnCommandChanging(BindableObject bindable, object oldCommand, object newCommand)
+        {
+            ContentButton button = (ContentButton)bindable;
+            if (oldCommand != null)
+            {
+                (oldCommand as ICommand).CanExecuteChanged -= button.OnCommandCanExecuteChanged;
+            }
+        }
+
+        static void CommandCanExcuteChanged(object sender, EventArgs e)
+        {
+            var button = (ContentButton)sender;
+            if (button.Command != null)
+            {
+                button.IsEnabledCore = button.Command.CanExecute(button.CommandParameter);
+            }
+        }
+
+        void OnCommandCanExecuteChanged(object sender, EventArgs e)
+        {
+            ContentButton button = (ContentButton)sender;
+            if (button.Command != null)
+            {
+                button.IsEnabledCore = button.Command.CanExecute(button.CommandParameter);
+            }
+        }
+    }
+}

--- a/src/Tizen.TV.UIControls.Forms/Renderer/ContentButtonRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/ContentButtonRenderer.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Flora License, Version 1.1 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Tizen;
+using XForms = Xamarin.Forms.Forms;
+using XFLayout = Xamarin.Forms.Layout;
+using EButton = ElmSharp.Button;
+using Tizen.TV.UIControls.Forms;
+using Tizen.TV.UIControls.Forms.Renderer;
+
+[assembly: ExportRenderer(typeof(ContentButton), typeof(ContentButtonRenderer))]
+
+namespace Tizen.TV.UIControls.Forms.Renderer
+{
+    public class ContentButtonRenderer : LayoutRenderer
+    {
+        EButton _button;
+
+        ContentButton Button => Element as ContentButton;
+
+        protected override void OnElementChanged(ElementChangedEventArgs<XFLayout> e)
+        {
+            base.OnElementChanged(e);
+            Initialize();
+        }
+
+        void Initialize()
+        {
+            if (_button == null)
+            {
+                _button = new EButton(XForms.NativeParent);
+                _button.SetTransparentStyle();
+                _button.Opacity = 0;
+                _button.Show();
+
+                _button.Pressed += OnPressed;
+                _button.Released += OnReleased;
+                _button.Clicked += OnClicked;
+                _button.Focused += OnButtonFocused;
+                _button.Unfocused += OnButtonFocused;
+                Control.PackEnd(_button);
+            }
+        }
+
+        void OnButtonFocused(object sender, EventArgs e)
+        {
+            if (_button.IsFocused)
+                OnFocused(this, e);
+            else 
+                OnUnfocused(this, e);
+        }
+
+        protected override void UpdateLayout()
+        {
+            base.UpdateLayout();
+
+            _button.Geometry = Control.Geometry;
+            _button.RaiseTop();
+        }
+
+        void OnPressed(object sender, EventArgs args)
+        {
+            Button?.SendPressed();
+        }
+
+        void OnReleased(object sender, EventArgs args)
+        {
+            Button?.SendReleased();
+        }
+
+        void OnClicked(object sender, EventArgs args)
+        {
+            Button?.SendClicked();
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
This PR introduce a control that makes all as button, All views could be a button with `ContentButton`
![contentbutton](https://user-images.githubusercontent.com/1029155/96542067-4e423900-12dc-11eb-8d0c-5d97c1b304e5.gif)


``` xml
<tv:ContentButton Clicked="ContentButton_Clicked">
    <Label FontSize="Header" x:Name="_label" Text="Text Button" />
</tv:ContentButton>
<tv:ContentButton Clicked="ContentButton_Clicked_1" HeightRequest="300" WidthRequest="300">
    <Image x:Name="_image" Source="albumarts/1984, Van Halen.jpg"/>
</tv:ContentButton>
```

### Bugs Fixed ###
 None

### API Changes ###
List all API changes here 
(or just put None when your changes are only bug fix, behavior change, add/fix testcase, add/fix sample), example:

Added:
 - class ContentButton 

### Behavioral Changes ###
Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

