### PR TITLE
Add ItemFocused event in RecycleItemsView

### DIFF
--- a/sample/Sample/RecycleItemsView/ItemFocusedEventTest.xaml
+++ b/sample/Sample/RecycleItemsView/ItemFocusedEventTest.xaml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tvcontrols="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             x:Class="Sample.RecycleItemsView.ItemFocusedEventTest"
+             NavigationPage.HasNavigationBar="False">
+    <ContentPage.Content>
+        <ScrollView>
+            <StackLayout>
+                <Label Text="BackgroundColor change"/>
+                <tvcontrols:RecycleItemsView
+                    x:Name="firstItems"
+                    BackgroundColor="AliceBlue"
+                    ContentMargin="100"
+                    ItemWidth="300"
+                    ItemHeight="200"
+                    Spacing="30"
+                    ItemsSource="{Binding Items}"
+                    ItemFocused="OnFirstItemsItemFocused">
+                    <tvcontrols:RecycleItemsView.ItemTemplate>
+                        <DataTemplate>
+                            <StackLayout BackgroundColor="{Binding Color}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
+                                <Label Text="{Binding Text}" VerticalOptions="Center" HorizontalOptions="Center"/>
+                            </StackLayout>
+                        </DataTemplate>
+                    </tvcontrols:RecycleItemsView.ItemTemplate>
+                </tvcontrols:RecycleItemsView>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Index is "/>
+                    <Label x:Name="itemIndex" Text="0"/>
+                </StackLayout>
+                <tvcontrols:RecycleItemsView 
+                    BackgroundColor="Coral"
+                    ContentMargin="100"
+                    ItemWidth="300"
+                    ItemHeight="200"
+                    Spacing="30"
+                    ItemFocused="OnSecondItemsItemFocused"
+                    ItemsSource="{Binding Items}">
+                    <tvcontrols:RecycleItemsView.ItemTemplate>
+                        <DataTemplate>
+                            <StackLayout BackgroundColor="{Binding Color}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
+                                <Label Text="{Binding Text}" VerticalOptions="Center" HorizontalOptions="Center"/>
+                            </StackLayout>
+                        </DataTemplate>
+                    </tvcontrols:RecycleItemsView.ItemTemplate>
+                </tvcontrols:RecycleItemsView>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/sample/Sample/RecycleItemsView/ItemFocusedEventTest.xaml.cs
+++ b/sample/Sample/RecycleItemsView/ItemFocusedEventTest.xaml.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Sample.RecycleItemsView
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class ItemFocusedEventTest : ContentPage
+    {
+        public ItemFocusedEventTest()
+        {
+            InitializeComponent ();
+        }
+
+        void OnFirstItemsItemFocused(object sender, Tizen.TV.UIControls.Forms.FocusedItemChangedEventArgs e)
+        {
+            var item = e.FocusedItem as ColorModel;
+            if(item != null)
+            {
+                firstItems.BackgroundColor = item.Color;
+            }
+        }
+
+        void OnSecondItemsItemFocused(object sender, Tizen.TV.UIControls.Forms.FocusedItemChangedEventArgs e)
+        {
+            itemIndex.Text = e.FocusedItemIndex.ToString();
+        }
+    }
+}

--- a/sample/Sample/RecycleItemsView/RecycleItemsViewModel.cs
+++ b/sample/Sample/RecycleItemsView/RecycleItemsViewModel.cs
@@ -111,6 +111,12 @@ namespace Sample.RecycleItemsView
                     PageType = typeof(HeaderTest),
                     Items = ColorModel.MakeModel()
                 },
+                new ItemsModel
+                {
+                    Name = "ItemFocused Event Test",
+                    PageType = typeof(ItemFocusedEventTest),
+                    Items = ColorModel.MakeModel()
+                },
             };
         }
     }

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -21,6 +21,9 @@
     <Compile Update="MediaPlayer\TestEmbeddingControlOnPage.xaml.cs">
       <DependentUpon>TestEmbeddingControlOnPage.xaml</DependentUpon>
     </Compile>
+    <Compile Update="RecycleItemsView\ItemFocusedEventTest.xaml.cs">
+      <DependentUpon>ItemFocusedEventTest.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="DrawerLayout\DrawerMainPage.xaml">

--- a/src/Tizen.TV.UIControls.Forms/FocusedItemChangedEventArgs.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusedItemChangedEventArgs.cs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Xamarin.Forms;
+
+namespace Tizen.TV.UIControls.Forms
+{
+    /// <summary>
+    /// Event arguments for the ItemFocused event.
+    /// </summary>
+    public class FocusedItemChangedEventArgs : EventArgs
+    {
+
+        /// <summary>
+        /// Creates a new FocusedItemChangedEventArgs event that indicates that the user has focused.
+        /// </summary>
+        /// <param name="focusedItem">The item is focused.</param>
+        /// <param name="focusedItemIndex">The item's index is focused.</param>
+        public FocusedItemChangedEventArgs(object focusedItem, int focusedItemIndex)
+        {
+            FocusedItem = focusedItem;
+            FocusedItemIndex = focusedItemIndex;
+        }
+
+        /// <summary>
+        /// Gets the new focused item.
+        /// </summary>
+        public object FocusedItem { get; private set; }
+
+        /// <summary>
+        /// Gets the new focused item's index.
+        /// </summary>
+        public int FocusedItemIndex { get; private set; }
+    }
+}

--- a/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
+++ b/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
@@ -502,6 +502,11 @@ namespace Tizen.TV.UIControls.Forms
         public event EventHandler<SelectedItemChangedEventArgs> ItemSelected;
 
         /// <summary>
+        /// Event that is raised when a new item is focused.
+        /// </summary>
+        public event EventHandler<FocusedItemChangedEventArgs> ItemFocused;
+
+        /// <summary>
         /// Event that is raised when a item's view is attached the RecycleItemsView.
         /// </summary>
         public event EventHandler<ItemRealizedEventArgs> ItemRealized;
@@ -729,6 +734,7 @@ namespace Tizen.TV.UIControls.Forms
                     SetValue(FocusedViewPropertyKey, targetView);
             }
             OnItemFocused(data, targetView, isFocused);
+            ItemFocused?.Invoke(this, new FocusedItemChangedEventArgs(FocusedItem, GetItemIndex(FocusedItem)));
         }
 
         bool ShouldReArrange()


### PR DESCRIPTION
### Description of Change ###
This PR add to raise an event when an item gets focus in Recycleitemsview.
![itemfocusedevent2](https://user-images.githubusercontent.com/16184582/97247202-84cf0500-1842-11eb-9ffa-3f5bccefc08a.gif)


### Bugs Fixed ###
- None


### API Changes ###

Added:
 - public event EventHandler<FocusedItemChangedEventArgs> ItemFocused;
 - public class FocusedItemChangedEventArgs : EventArgs
 

### Behavioral Changes ###


