### PR TITLE
Update Xamarin.Forms to 5.0.0-pre3

### DIFF
--- a/sample/Sample.Tizen/Sample.Tizen.cs
+++ b/sample/Sample.Tizen/Sample.Tizen.cs
@@ -25,7 +25,13 @@ namespace Sample
             var app = new Program();
             try
             {
-                Forms.Init(app);
+                var option = new InitializationOptions(app)
+                {
+                    //Using DP without device scaling mode
+                    DisplayResolutionUnit = DisplayResolutionUnit.DP()
+                };
+                Forms.Init(option);
+
                 // UIControls.Init() should be called after Forms.Init()
                 UIControls.Init(new InitOptions(app));
                 app.Run(args);

--- a/sample/Sample/ContentPopup/ContentPopupBGColorTest.xaml
+++ b/sample/Sample/ContentPopup/ContentPopupBGColorTest.xaml
@@ -17,8 +17,7 @@
                     HeightRequest="200"
                     HorizontalOptions="Center"
                     Text="Show Popup"
-                    VerticalOptions="CenterAndExpand"
-                    WidthRequest="500" />
+                    VerticalOptions="CenterAndExpand"/>
             <Button
                     AutomationId="dismisstest2"
                     x:Name="button2"
@@ -26,8 +25,7 @@
                     HeightRequest="100"
                     HorizontalOptions="Center"
                     Text="Show Popup (Full Screen)"
-                    VerticalOptions="CenterAndExpand"
-                    WidthRequest="500" />
+                    VerticalOptions="CenterAndExpand"/>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/sample/Sample/ContentPopup/ContentPopupBasicTest.xaml
+++ b/sample/Sample/ContentPopup/ContentPopupBasicTest.xaml
@@ -18,8 +18,7 @@
                     HeightRequest="100"
                     HorizontalOptions="Center"
                     Text="Show Popup"
-                    VerticalOptions="CenterAndExpand"
-                    WidthRequest="500" />
+                    VerticalOptions="CenterAndExpand"/>
             <Button
                     AutomationId="dismisstest2"
                     x:Name="button2"
@@ -27,8 +26,7 @@
                     HeightRequest="100"
                     HorizontalOptions="Center"
                     Text="Show Popup (Full Screen)"
-                    VerticalOptions="CenterAndExpand"
-                    WidthRequest="500" />
+                    VerticalOptions="CenterAndExpand"/>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/sample/Sample/DrawerLayout/DrawerBasicTest.cs
+++ b/sample/Sample/DrawerLayout/DrawerBasicTest.cs
@@ -10,10 +10,10 @@ namespace Sample.DrawerLayout
             Title = "Basic Test";
             Content = new Tizen.TV.UIControls.Forms.DrawerLayout()
             {
-                DrawerClosedWidth = 30,
+                DrawerClosedWidth = 60,
                 Drawer = new StackLayout
                 {
-                    WidthRequest = 500,
+                    WidthRequest = 1000,
                     BackgroundColor = Color.Coral,
                     Children =
                     {
@@ -28,7 +28,7 @@ namespace Sample.DrawerLayout
                 },
                 Content = new StackLayout
                 {
-                    WidthRequest = 900,
+                    WidthRequest = 1800,
                     BackgroundColor = Color.Brown,
                     Children =
                     {

--- a/sample/Sample/DrawerLayout/DrawerSample1.xaml
+++ b/sample/Sample/DrawerLayout/DrawerSample1.xaml
@@ -8,11 +8,11 @@
     <ContentPage.Content>
         <tv:DrawerLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand"
                          IsOpen="{Binding IsFocused, Source={x:Reference MenuList}}"
-                         DrawerClosedWidth="30">
+                         DrawerClosedWidth="60">
             <tv:DrawerLayout.Drawer>
                 <local:MenuItemsView x:Name="MenuList"
-                                     ItemWidth="500"
-                                     ItemHeight="100" Orientation="Vertical" ItemsSource="{Binding Items}"
+                                     ItemWidth="1000"
+                                     ItemHeight="200" Orientation="Vertical" ItemsSource="{Binding Items}"
                                      BackgroundColor="DarkSlateBlue"
                                      ItemSelected="MenuItemsView_ItemSelected"/>
             </tv:DrawerLayout.Drawer>

--- a/sample/Sample/DrawerLayout/DrawerSample1.xaml.cs
+++ b/sample/Sample/DrawerLayout/DrawerSample1.xaml.cs
@@ -26,7 +26,7 @@ namespace Sample.DrawerLayout
                 {
                     VerticalOptions = LayoutOptions.FillAndExpand,
                     HorizontalOptions = LayoutOptions.FillAndExpand,
-                    Padding = 20,
+                    Padding = 40,
                     Children =
                     {
                         label,

--- a/sample/Sample/DrawerLayout/DrawerSample2.xaml
+++ b/sample/Sample/DrawerLayout/DrawerSample2.xaml
@@ -10,8 +10,8 @@
                          DrawerClosedWidth="0">
             <tv:DrawerLayout.Drawer>
                 <local:MenuItemsView x:Name="MenuList"
-                                     ItemWidth="500"
-                                     ItemHeight="100" Orientation="Vertical" ItemsSource="{Binding Items}"
+                                     ItemWidth="1000"
+                                     ItemHeight="200" Orientation="Vertical" ItemsSource="{Binding Items}"
                                      BackgroundColor="DarkSlateBlue"
                                      ItemSelected="MenuList_ItemSelected"/>
             </tv:DrawerLayout.Drawer>

--- a/sample/Sample/DrawerLayout/NestedDrawerPage.xaml
+++ b/sample/Sample/DrawerLayout/NestedDrawerPage.xaml
@@ -8,12 +8,12 @@
     <ContentPage.Content>
         <tv:DrawerLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
             <tv:DrawerLayout.Drawer>
-                <local:FocusedMenuItemsView x:Name="MainMenuList" Orientation="Vertical" ItemsSource="{Binding Items}" ItemWidth="300" ItemHeight="100" BackgroundColor="DarkGreen" ItemFocused="MainMenuList_ItemFocused"/>
+                <local:MenuItemsView x:Name="MainMenuList" Orientation="Vertical" ItemsSource="{Binding Items}" ItemWidth="600" ItemHeight="200" BackgroundColor="DarkGreen" ItemFocused="MainMenuList_ItemFocused"/>
             </tv:DrawerLayout.Drawer>
             <tv:DrawerLayout.Content>
                 <tv:DrawerLayout x:Name="SubDrawer" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
                     <tv:DrawerLayout.Drawer>
-                        <local:FocusedMenuItemsView Orientation="Vertical" x:Name="SubMenuList" ItemWidth="200" ItemHeight="100" BackgroundColor="BlueViolet" ItemFocused="SubMenuList_ItemFocused"/>
+                        <local:MenuItemsView Orientation="Vertical" x:Name="SubMenuList" ItemWidth="400" ItemHeight="200" BackgroundColor="BlueViolet" ItemFocused="SubMenuList_ItemFocused"/>
                     </tv:DrawerLayout.Drawer>
                     <tv:DrawerLayout.Content>
                         <StackLayout BackgroundColor="White">

--- a/sample/Sample/DrawerLayout/NestedDrawerPage.xaml.cs
+++ b/sample/Sample/DrawerLayout/NestedDrawerPage.xaml.cs
@@ -4,19 +4,6 @@ using Xamarin.Forms.Xaml;
 
 namespace Sample.DrawerLayout
 {
-    public class FocusedMenuItemsView : MenuItemsView
-    {
-        public event EventHandler ItemFocused;
-        protected override void OnItemFocused(object data, View targetView, bool isFocused)
-        {
-            base.OnItemFocused(data, targetView, isFocused);
-            if (isFocused)
-            {
-                ItemFocused?.Invoke(this, EventArgs.Empty);
-            }
-        }
-    }
-
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class NestedDrawerPage : ContentPage
     {

--- a/sample/Sample/DrawerLayout/RightDrawerTest.xaml
+++ b/sample/Sample/DrawerLayout/RightDrawerTest.xaml
@@ -8,10 +8,10 @@
         <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
             <tv:DrawerLayout x:Name="Drawer" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
                              DrawerPosition="Right"
-                             DrawerClosedWidth="40"
+                             DrawerClosedWidth="80"
                              IsOpen="{Binding IsToggled, Source={x:Reference OpenSwitch}}">
                 <tv:DrawerLayout.Drawer>
-                    <BoxView Color="CornflowerBlue" WidthRequest="300"/>
+                    <BoxView Color="CornflowerBlue" WidthRequest="600"/>
                 </tv:DrawerLayout.Drawer>
                 <tv:DrawerLayout.Content>
                     <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" BackgroundColor="Coral">

--- a/sample/Sample/Entry/TestEntry.cs
+++ b/sample/Sample/Entry/TestEntry.cs
@@ -16,13 +16,11 @@
 
 using System;
 using Xamarin.Forms;
-using Tizen.TV.UIControls.Forms;
 
 namespace Sample
 {
     public class TestEntry : ContentPage
     {
-        int _clickedTimes = 0;
         public TestEntry()
         {
             Label statusLabel = new Label();

--- a/sample/Sample/MediaPlayer/SimplePlayerPage.xaml
+++ b/sample/Sample/MediaPlayer/SimplePlayerPage.xaml
@@ -2,7 +2,7 @@
 <tvcontrols:OverlayPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:tvcontrols="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
-             xmlns:local="Sample.TestOverlayPage"
+             xmlns:local="clr-namespace:Sample"
              x:Class="Sample.SimplePlayerPage">
     <ContentPage.Resources>
         <ResourceDictionary>
@@ -11,27 +11,27 @@
         </ResourceDictionary>
     </ContentPage.Resources>
     <tvcontrols:OverlayPage.Player>
-        <tvcontrols:MediaPlayer x:Name="Player" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="False"/>
+        <tvcontrols:MediaPlayer x:Name="MediaPlayer" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="False"/>
     </tvcontrols:OverlayPage.Player>
     <AbsoluteLayout>
         <Label FontSize="Large"
                HorizontalTextAlignment="Center"
-               Text="{Binding Source={x:Reference Player}, Path=BufferingProgress, StringFormat='{}{0:0%}'}"
+               Text="{Binding Source={x:Reference MediaPlayer}, Path=BufferingProgress, StringFormat='{}{0:0%}'}"
                AbsoluteLayout.LayoutFlags="All"
                AbsoluteLayout.LayoutBounds="0.5, 0.5, .25, .25"
-               IsVisible="{Binding Source={x:Reference Player}, Path=IsBuffering}"/>
+               IsVisible="{Binding Source={x:Reference MediaPlayer}, Path=IsBuffering}"/>
         <StackLayout Padding="50" HorizontalOptions="FillAndExpand" VerticalOptions="End" BackgroundColor="#20000000" AbsoluteLayout.LayoutFlags="All" AbsoluteLayout.LayoutBounds="0, 0, 1, 1">
-            <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference Player}, Path=Duration, StringFormat='Duration {0}ms'}"/>
-            <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference Player}, Path=IsMuted, StringFormat='IsMuted {0}'}"/>
-            <Switch HorizontalOptions="Center" IsToggled="{Binding Source={x:Reference Player}, Path=IsMuted, Mode=TwoWay}"/>
+            <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference MediaPlayer}, Path=Duration, StringFormat='Duration {0}ms'}"/>
+            <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference MediaPlayer}, Path=IsMuted, StringFormat='IsMuted {0}'}"/>
+            <Switch HorizontalOptions="Center" IsToggled="{Binding Source={x:Reference MediaPlayer}, Path=IsMuted, Mode=TwoWay}"/>
             <StackLayout Orientation="Horizontal" Spacing="10" HorizontalOptions="Center">
                 <Label Text="Volume"/>
-                <Slider Value="{Binding Source={x:Reference Player}, Path=Volume}"/>
+                <Slider Value="{Binding Source={x:Reference MediaPlayer}, Path=Volume}"/>
             </StackLayout>
             <Slider HorizontalOptions="FillAndExpand" x:Name="Seekbar" ValueChanged="OnSeekChanged"/>
-            <ProgressBar HorizontalOptions="FillAndExpand" Progress="{Binding Source={x:Reference Player}, Path=Position, Converter={StaticResource positionToProgress}, ConverterParameter={x:Reference Player}}}"/>
+            <ProgressBar HorizontalOptions="FillAndExpand" Progress="{Binding Source={x:Reference MediaPlayer}, Path=Position, Converter={StaticResource positionToProgress}, ConverterParameter={x:Reference MediaPlayer}}}"/>
             <StackLayout Orientation="Horizontal">
-                <Button Text="{Binding Source={x:Reference Player}, Path=State, Converter={StaticResource stateToLabel}}" Clicked="OnPlayClicked"/>
+                <Button Text="{Binding Source={x:Reference MediaPlayer}, Path=State, Converter={StaticResource stateToLabel}}" Clicked="OnPlayClicked"/>
                 <Button Text="□" Clicked="OnStopClicked"/>
             </StackLayout>
         </StackLayout>

--- a/sample/Sample/MediaPlayer/SimplePlayerPage.xaml.cs
+++ b/sample/Sample/MediaPlayer/SimplePlayerPage.xaml.cs
@@ -32,35 +32,35 @@ namespace Sample
 
         void OnClickPlay(object sender, ClickedEventArgs e)
         {
-            if (Player.State == PlaybackState.Playing)
-                Player.Pause();
+            if (MediaPlayer.State == PlaybackState.Playing)
+                MediaPlayer.Pause();
             else
             {
-                var unused = Player.Start();
+                var unused = MediaPlayer.Start();
             }
         }
 
         void OnClickStop(object sender, ClickedEventArgs e)
         {
-            Player.Stop();
+            MediaPlayer.Stop();
         }
 
         async void OnSeekChanged(object sender, ValueChangedEventArgs e)
         {
-            await Player.Seek((int)(Player.Duration * e.NewValue));
+            await MediaPlayer.Seek((int)(MediaPlayer.Duration * e.NewValue));
         }
 
         void OnPlayClicked(object sender, EventArgs e)
         {
-            if (Player.State != PlaybackState.Playing)
-                Player.Start();
+            if (MediaPlayer.State != PlaybackState.Playing)
+                MediaPlayer.Start();
             else
-                Player.Pause();
+                MediaPlayer.Pause();
         }
 
         void OnStopClicked(object sender, EventArgs e)
         {
-            Player.Stop();
+            MediaPlayer.Stop();
         }
     }
 }

--- a/sample/Sample/MediaPlayer/SimplePlayerPage2.xaml
+++ b/sample/Sample/MediaPlayer/SimplePlayerPage2.xaml
@@ -5,6 +5,6 @@
              x:Class="Sample.SimplePlayerPage2"
              NavigationPage.HasNavigationBar="False">
     <tvcontrols:OverlayPage.Player>
-        <tvcontrols:MediaPlayer x:Name="Player" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="True"/>
+        <tvcontrols:MediaPlayer x:Name="MediaPlayer" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="True"/>
     </tvcontrols:OverlayPage.Player>
 </tvcontrols:OverlayPage>

--- a/sample/Sample/MediaPlayer/TestAspect.xaml
+++ b/sample/Sample/MediaPlayer/TestAspect.xaml
@@ -4,7 +4,7 @@
              xmlns:tvcontrols="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
              x:Class="Sample.TestAspect">
     <tvcontrols:OverlayPage.Player>
-        <tvcontrols:MediaPlayer x:Name="Player" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="False"/>
+        <tvcontrols:MediaPlayer x:Name="MediaPlayer" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="False"/>
     </tvcontrols:OverlayPage.Player>
     <StackLayout Orientation="Horizontal" VerticalOptions="End" HorizontalOptions="Center">
         <Button Text="AspectFit" Clicked="OnAspectFit"></Button>

--- a/sample/Sample/MediaPlayer/TestAspect.xaml.cs
+++ b/sample/Sample/MediaPlayer/TestAspect.xaml.cs
@@ -35,20 +35,20 @@ namespace Sample
 
         void OnAspectFill(object sender, EventArgs e)
         {
-            Player.AspectMode = DisplayAspectMode.AspectFill;
+            MediaPlayer.AspectMode = DisplayAspectMode.AspectFill;
         }
         void OnAspectFit(object sender, EventArgs e)
         {
-            Player.AspectMode = DisplayAspectMode.AspectFit;
+            MediaPlayer.AspectMode = DisplayAspectMode.AspectFit;
         }
         void OnOriginal(object sender, EventArgs e)
         {
-            Player.AspectMode = DisplayAspectMode.OrignalSize;
+            MediaPlayer.AspectMode = DisplayAspectMode.OrignalSize;
         }
 
         void OnFill(object sender, EventArgs e)
         {
-            Player.AspectMode = DisplayAspectMode.Fill;
+            MediaPlayer.AspectMode = DisplayAspectMode.Fill;
         }
     }
 }

--- a/sample/Sample/MediaPlayer/TestEmbeddingControlOnPage.xaml
+++ b/sample/Sample/MediaPlayer/TestEmbeddingControlOnPage.xaml
@@ -5,9 +5,9 @@
              NavigationPage.HasNavigationBar="false"
              x:Class="Sample.TestEmbeddingControlOnPage">
     <tvcontrols:OverlayPage.Player>
-        <tvcontrols:MediaPlayer x:Name="Player" Source="{Binding Source}" UsesEmbeddingControls="true" AutoPlay="true" PositionUpdateInterval="100"></tvcontrols:MediaPlayer>
+        <tvcontrols:MediaPlayer x:Name="MediaPlayer" Source="{Binding Source}" UsesEmbeddingControls="true" AutoPlay="true" PositionUpdateInterval="100"></tvcontrols:MediaPlayer>
     </tvcontrols:OverlayPage.Player>
     <StackLayout VerticalOptions="Start">
-        <Button Text="{Binding Source={x:Reference Player}, Path=UsesEmbeddingControls, StringFormat='UsesEmbeddingControls = {0}'}}" x:Name="Btn"/>
+        <Button Text="{Binding Source={x:Reference MediaPlayer}, Path=UsesEmbeddingControls, StringFormat='UsesEmbeddingControls = {0}'}}" x:Name="Btn"/>
     </StackLayout>
 </tvcontrols:OverlayPage>

--- a/sample/Sample/MediaPlayer/TestEmbeddingControlOnPage.xaml.cs
+++ b/sample/Sample/MediaPlayer/TestEmbeddingControlOnPage.xaml.cs
@@ -37,7 +37,7 @@ namespace Sample
 
         void OnClick(object sender, EventArgs e)
         {
-            Player.UsesEmbeddingControls = !Player.UsesEmbeddingControls;
+            MediaPlayer.UsesEmbeddingControls = !MediaPlayer.UsesEmbeddingControls;
         }
     }
 }

--- a/sample/Sample/MediaPlayer/TestOverlayPage.xaml
+++ b/sample/Sample/MediaPlayer/TestOverlayPage.xaml
@@ -2,7 +2,7 @@
 <tvcontrols:OverlayPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:tvcontrols="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
-             xmlns:local="Sample.TestOverlayPage"
+             xmlns:local="clr-namespace:Sample"
              x:Class="Sample.TestOverlayPage">
     <ContentPage.Resources>
         <ResourceDictionary>
@@ -10,10 +10,10 @@
         </ResourceDictionary>           
     </ContentPage.Resources>
     <tvcontrols:OverlayPage.Player>
-        <tvcontrols:MediaPlayer x:Name="Player" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="False"/>
+        <tvcontrols:MediaPlayer x:Name="MediaPlayer" Source="{Binding Source}" AutoPlay="true" UsesEmbeddingControls="False"/>
     </tvcontrols:OverlayPage.Player>
     <StackLayout Padding="50" HorizontalOptions="FillAndExpand" VerticalOptions="End" BackgroundColor="#20000000">
-        <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference Player}, Path=Duration, StringFormat='Duration {0}ms'}"/>
-        <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference Player}, Path=BufferingProgress, StringFormat='{}{0:Buffering 0%}'}"/>
+        <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference MediaPlayer}, Path=Duration, StringFormat='Duration {0}ms'}"/>
+        <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference MediaPlayer}, Path=BufferingProgress, StringFormat='{}{0:Buffering 0%}'}"/>
     </StackLayout>
 </tvcontrols:OverlayPage>

--- a/sample/Sample/RecycleItemsView/ColumnTest.xaml
+++ b/sample/Sample/RecycleItemsView/ColumnTest.xaml
@@ -8,10 +8,10 @@
         <ScrollView>
             <StackLayout>
                 <tvcontrols:RecycleItemsView BackgroundColor="AliceBlue" ColumnCount="3"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -22,10 +22,10 @@
                     </tvcontrols:RecycleItemsView.ItemTemplate>
                 </tvcontrols:RecycleItemsView>
                 <tvcontrols:RecycleItemsView BackgroundColor="DeepPink" ColumnCount="2"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -36,10 +36,10 @@
                     </tvcontrols:RecycleItemsView.ItemTemplate>
                 </tvcontrols:RecycleItemsView>
                 <tvcontrols:RecycleItemsView BackgroundColor="Coral" ColumnCount="5"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>

--- a/sample/Sample/RecycleItemsView/CustomFocus.xaml
+++ b/sample/Sample/RecycleItemsView/CustomFocus.xaml
@@ -8,18 +8,18 @@
     <ContentPage.Content>
         <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="Center">
             <Label Text="Movies" FontAttributes="Bold" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Start" FontSize="Large"/>
-            <local:MyRecycleItemsView HorizontalOptions="FillAndExpand" BackgroundColor="Brown" HeightRequest="800"
+            <local:MyRecycleItemsView HorizontalOptions="FillAndExpand" BackgroundColor="Brown" HeightRequest="1600"
                     ScrollBarVisibility="Never"
-                    ContentMargin="100"
-                    ItemWidth="480"
-                    Spacing="50"
+                    ContentMargin="200"
+                    ItemWidth="960"
+                    Spacing="100"
                     ItemsSource="{Binding Items}"
                     ItemSelected="OnSelected">
                 <tvcontrols:RecycleItemsView.ItemTemplate>
                     <DataTemplate>
                         <AbsoluteLayout BackgroundColor="CadetBlue">
                             <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
-                            <StackLayout Padding="20" AbsoluteLayout.LayoutBounds="0, 1, 480, 100" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                            <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
                                 <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
                                 <Label Text="{Binding DetailText}" FontSize="40"/>
                             </StackLayout>

--- a/sample/Sample/RecycleItemsView/CustomFocus.xaml.cs
+++ b/sample/Sample/RecycleItemsView/CustomFocus.xaml.cs
@@ -32,7 +32,7 @@ namespace Sample.RecycleItemsView
                 targetView.ScaleTo(1.2);
                 var animation = new Animation((rate) =>
                 {
-                    AbsoluteLayout.SetLayoutBounds(textarea, new Rectangle(0, 1, 480, 100 + rate * 100));
+                    AbsoluteLayout.SetLayoutBounds(textarea, new Rectangle(0, 1, 960, 200 + rate * 200));
                 });
                 animation.Commit(this, $"Focused - {data.GetHashCode()}");
             }
@@ -41,7 +41,7 @@ namespace Sample.RecycleItemsView
                 targetView.ScaleTo(1.0);
                 var animation = new Animation((rate) =>
                 {
-                    AbsoluteLayout.SetLayoutBounds(textarea, new Rectangle(0, 1, 480, 200 - rate * 100));
+                    AbsoluteLayout.SetLayoutBounds(textarea, new Rectangle(0, 1, 960, 400 - rate * 200));
                 });
                 animation.Commit(this, $"Focused - {data.GetHashCode()}");
             }

--- a/sample/Sample/RecycleItemsView/DefaultItemTemplateTest.xaml
+++ b/sample/Sample/RecycleItemsView/DefaultItemTemplateTest.xaml
@@ -6,10 +6,10 @@
     <ContentPage.Content>
         <StackLayout>
             <tvcontrols:RecycleItemsView 
-                    ContentMargin="100"
-                    ItemWidth="300"
-                    ItemHeight="200"
-                    Spacing="30">
+                    ContentMargin="200"
+                    ItemWidth="600"
+                    ItemHeight="400"
+                    Spacing="60">
                 <tvcontrols:RecycleItemsView.ItemsSource>
                     <x:Array Type="{x:Type x:String}">
                         <x:String>Item1</x:String>

--- a/sample/Sample/RecycleItemsView/FocusChainTest.xaml
+++ b/sample/Sample/RecycleItemsView/FocusChainTest.xaml
@@ -7,23 +7,23 @@
     <ContentPage.Content>
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="100" />
+                <RowDefinition Height="200" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="*" />
-                <RowDefinition Height="100" />
+                <RowDefinition Height="200" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="100" />
+                <ColumnDefinition Width="200" />
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="100" />
+                <ColumnDefinition Width="200" />
             </Grid.ColumnDefinitions>
             <tvcontrols:RecycleItemsView Orientation="Horizontal" Grid.Column="1" Grid.Row="1" x:Name="ItemsView1"
                                          ItemsSource="{Binding Items}"
-                                         ItemHeight="150"
-                                         ContentMargin="10"
-                                         ItemWidth="100">
+                                         ItemHeight="300"
+                                         ContentMargin="20"
+                                         ItemWidth="200">
                 <tvcontrols:RecycleItemsView.ItemTemplate>
                     <DataTemplate>
                         <StackLayout BackgroundColor="{Binding Color}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
@@ -35,9 +35,9 @@
 
             <tvcontrols:RecycleItemsView Orientation="Horizontal" Grid.Column="1" Grid.Row="2" x:Name="ItemsView2"
                                          ItemsSource="{Binding Items}"
-                                         ItemHeight="150"
-                                         ContentMargin="10"
-                                         ItemWidth="100">
+                                         ItemHeight="300"
+                                         ContentMargin="20"
+                                         ItemWidth="200">
                 <tvcontrols:RecycleItemsView.ItemTemplate>
                     <DataTemplate>
                         <StackLayout BackgroundColor="{Binding Color}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
@@ -49,9 +49,9 @@
 
             <tvcontrols:RecycleItemsView Orientation="Horizontal" Grid.Column="1" Grid.Row="3" x:Name="ItemsView3"
                                          ItemsSource="{Binding Items}"
-                                         ItemHeight="150"
-                                         ContentMargin="10"
-                                         ItemWidth="100">
+                                         ItemHeight="300"
+                                         ContentMargin="20"
+                                         ItemWidth="200">
                 <tvcontrols:RecycleItemsView.ItemTemplate>
                     <DataTemplate>
                         <StackLayout BackgroundColor="{Binding Color}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
@@ -63,9 +63,9 @@
 
             <tvcontrols:RecycleItemsView Orientation="Horizontal" Grid.Column="1" Grid.Row="4" x:Name="ItemsView4"
                                          ItemsSource="{Binding Items}"
-                                         ItemHeight="150"
-                                         ContentMargin="10"
-                                         ItemWidth="100">
+                                         ItemHeight="300"
+                                         ContentMargin="20"
+                                         ItemWidth="200">
                 <tvcontrols:RecycleItemsView.ItemTemplate>
                     <DataTemplate>
                         <StackLayout BackgroundColor="{Binding Color}" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">

--- a/sample/Sample/RecycleItemsView/HeaderTest.xaml
+++ b/sample/Sample/RecycleItemsView/HeaderTest.xaml
@@ -8,13 +8,13 @@
     <ContentPage.Content>
         <StackLayout HorizontalOptions="FillAndExpand">
             <local:ColorListView Orientation="Vertical" ColumnCount="5"
-                        ContentMargin="100"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemHeight="400"
+                        Spacing="60"
                         AllowFocusHeader="False"
                         ItemsSource="{Binding Items}">
                 <tvcontrols:RecycleItemsView.Header>
-                    <StackLayout HeightRequest="200" Padding="20" BackgroundColor="Coral">
+                    <StackLayout HeightRequest="400" Padding="40" BackgroundColor="Coral">
                         <Label VerticalOptions="CenterAndExpand" FontSize="Large" Text="Color List"/>
                     </StackLayout>
                 </tvcontrols:RecycleItemsView.Header>

--- a/sample/Sample/RecycleItemsView/HorizontalTest.xaml
+++ b/sample/Sample/RecycleItemsView/HorizontalTest.xaml
@@ -10,10 +10,10 @@
                 <Label Text="ScrollPolicy=Center"/>
                 <tvcontrols:RecycleItemsView BackgroundColor="AliceBlue"
                         ScrollPolicy="Center"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -26,10 +26,10 @@
                 <Label Text="ScrollPolicy=MakeVisible"/>
                 <tvcontrols:RecycleItemsView BackgroundColor="DeepPink"
                         ScrollPolicy="MakeVisible"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -42,10 +42,10 @@
                 <Label Text="ScrollPolicy=Start"/>
                 <tvcontrols:RecycleItemsView BackgroundColor="Coral"
                         ScrollPolicy="Start"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -58,10 +58,10 @@
                 <Label Text="ScrollPolicy=End"/>
                 <tvcontrols:RecycleItemsView BackgroundColor="Moccasin"
                         ScrollPolicy="End"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>

--- a/sample/Sample/RecycleItemsView/ImageCellTest.xaml
+++ b/sample/Sample/RecycleItemsView/ImageCellTest.xaml
@@ -8,10 +8,10 @@
         <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="Center">
             <Label Text="Music" FontAttributes="Bold" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Start" FontSize="Large"/>
             <tvcontrols:RecycleItemsView HorizontalOptions="FillAndExpand" BackgroundColor="Beige"
-                    ContentMargin="100"
-                    ItemWidth="400"
-                    ItemHeight="400"
-                    Spacing="30"
+                    ContentMargin="200"
+                    ItemWidth="800"
+                    ItemHeight="800"
+                    Spacing="60"
                     Footer="More"
                     ItemsSource="{Binding Items}"
                     ItemSelected="OnSelected">
@@ -22,8 +22,8 @@
                 </tvcontrols:RecycleItemsView.ItemTemplate>
                 <tvcontrols:RecycleItemsView.FooterTemplate>
                     <DataTemplate>
-                        <StackLayout WidthRequest="300" Padding="20" BackgroundColor="#5b6b72">
-                            <Image Source="img_profile_c.png" HorizontalOptions="Center" VerticalOptions="CenterAndExpand" WidthRequest="200" HeightRequest="200"/>
+                        <StackLayout WidthRequest="600" Padding="40" BackgroundColor="#5b6b72">
+                            <Image Source="img_profile_c.png" HorizontalOptions="Center" VerticalOptions="CenterAndExpand" WidthRequest="200" HeightRequest="400"/>
                             <Label Text="Music" TextColor="AntiqueWhite" FontAttributes="Bold" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand"/>
                         </StackLayout>
                     </DataTemplate>

--- a/sample/Sample/RecycleItemsView/ItemFocusedEventTest.xaml
+++ b/sample/Sample/RecycleItemsView/ItemFocusedEventTest.xaml
@@ -11,10 +11,10 @@
                 <tvcontrols:RecycleItemsView
                     x:Name="firstItems"
                     BackgroundColor="AliceBlue"
-                    ContentMargin="100"
-                    ItemWidth="300"
-                    ItemHeight="200"
-                    Spacing="30"
+                    ContentMargin="200"
+                    ItemWidth="600"
+                    ItemHeight="400"
+                    Spacing="60"
                     ItemsSource="{Binding Items}"
                     ItemFocused="OnFirstItemsItemFocused">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
@@ -31,10 +31,10 @@
                 </StackLayout>
                 <tvcontrols:RecycleItemsView 
                     BackgroundColor="Coral"
-                    ContentMargin="100"
-                    ItemWidth="300"
-                    ItemHeight="200"
-                    Spacing="30"
+                    ContentMargin="200"
+                    ItemWidth="600"
+                    ItemHeight="400"
+                    Spacing="60"
                     ItemFocused="OnSecondItemsItemFocused"
                     ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>

--- a/sample/Sample/RecycleItemsView/TextCellTest.xaml
+++ b/sample/Sample/RecycleItemsView/TextCellTest.xaml
@@ -8,10 +8,10 @@
         <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="Center">
             <Label Text="Movie" FontAttributes="Bold" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Start" FontSize="Large"/>
             <tvcontrols:RecycleItemsView HorizontalOptions="FillAndExpand" BackgroundColor="Beige"
-                    ContentMargin="100"
-                    ItemWidth="400"
-                    ItemHeight="400"
-                    Spacing="30"
+                    ContentMargin="200"
+                    ItemWidth="800"
+                    ItemHeight="800"
+                    Spacing="60"
                     ItemsSource="{Binding Items}">
                 <tvcontrols:RecycleItemsView.ItemTemplate>
                     <DataTemplate>

--- a/sample/Sample/RecycleItemsView/VertialHorzontalTest.xaml
+++ b/sample/Sample/RecycleItemsView/VertialHorzontalTest.xaml
@@ -7,13 +7,13 @@
              x:Class="Sample.RecycleItemsView.VertialHorzontalTest">
     <ContentPage.Content>
         <StackLayout Orientation="Horizontal" Spacing="0" Margin="0">
-            <StackLayout x:Name="Sidebar" Orientation="Vertical" Spacing="20" WidthRequest="1">
+            <StackLayout x:Name="Sidebar" Orientation="Vertical" Spacing="40" WidthRequest="1">
                 <Label FontSize="Large" Text="Home"/>
-                <local:MenuItemsView x:Name="MenuList" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" WidthRequest="300"
-                    Orientation="Vertical" ItemHeight="100" ItemWidth="300" ContentMargin="0" Spacing="0" ItemsSource="{Binding Items2}">
+                <local:MenuItemsView x:Name="MenuList" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" WidthRequest="600"
+                    Orientation="Vertical" ItemHeight="200" ItemWidth="600" ContentMargin="0" Spacing="0" ItemsSource="{Binding Items2}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
-                            <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Padding="20">
+                            <StackLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand" Padding="40">
                                 <Label Text="{Binding Text}" FontAttributes="Bold" VerticalOptions="FillAndExpand" VerticalTextAlignment="Center"/>
                             </StackLayout>
                         </DataTemplate>
@@ -25,10 +25,10 @@
                     <tvcontrols:RecycleItemsView x:Name="RecycleView" BackgroundColor="AliceBlue" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
                         ItemSelected="OnSelected"
                         ScrollPolicy="Center"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                         <tvcontrols:RecycleItemsView.ItemTemplate>
                             <DataTemplate>
@@ -42,10 +42,10 @@
                     </tvcontrols:RecycleItemsView>
                     <tvcontrols:RecycleItemsView BackgroundColor="AliceBlue" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
                         ScrollPolicy="Center"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                         <tvcontrols:RecycleItemsView.ItemTemplate>
                             <DataTemplate>
@@ -55,10 +55,10 @@
                     </tvcontrols:RecycleItemsView>
                     <tvcontrols:RecycleItemsView BackgroundColor="AliceBlue" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
                         ScrollPolicy="Center"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                         <tvcontrols:RecycleItemsView.ItemTemplate>
                             <DataTemplate>
@@ -70,10 +70,10 @@
                     </tvcontrols:RecycleItemsView>
                     <tvcontrols:RecycleItemsView BackgroundColor="AliceBlue" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand"
                         ScrollPolicy="Center"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                         <tvcontrols:RecycleItemsView.ItemTemplate>
                             <DataTemplate>
@@ -83,9 +83,8 @@
                             </DataTemplate>
                         </tvcontrols:RecycleItemsView.ItemTemplate>
                     </tvcontrols:RecycleItemsView>
-
                 </StackLayout>
             </ScrollView>
-        </StackLayout>            
+        </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/sample/Sample/RecycleItemsView/VertialHorzontalTest.xaml.cs
+++ b/sample/Sample/RecycleItemsView/VertialHorzontalTest.xaml.cs
@@ -61,19 +61,19 @@ namespace Sample.RecycleItemsView
         {
             if (e.IsFocused)
             {
-                double start = (Sidebar.WidthRequest - 1) / 400.0;
+                double start = (Sidebar.WidthRequest - 1) / 800.0;
                 var animation = new Animation((r) =>
                 {
-                    Sidebar.WidthRequest = 400 * r;
+                    Sidebar.WidthRequest = 800 * r;
                 }, start, 1, Easing.SpringIn);
                 animation.Commit(Sidebar, "Focus", length: (uint)(250 * (1 - start)));
             }
             else
             {
-                double start = (400 - Sidebar.WidthRequest) / 400.0;
+                double start = (800 - Sidebar.WidthRequest) / 800.0;
                 var animation = new Animation((r) =>
                 {
-                    Sidebar.WidthRequest = 400 * (1 - r) + 1;
+                    Sidebar.WidthRequest = 800 * (1 - r) + 1;
                 }, start, 1, Easing.SpringIn);
                 animation.Commit(Sidebar, "Focus", length: (uint)(250 * (1 - start)));
             }

--- a/sample/Sample/RecycleItemsView/VerticalTest.xaml
+++ b/sample/Sample/RecycleItemsView/VerticalTest.xaml
@@ -10,10 +10,10 @@
                 <tvcontrols:RecycleItemsView BackgroundColor="AliceBlue"
                         Orientation="Vertical"
                         ScrollPolicy="Center"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -26,10 +26,10 @@
                 <tvcontrols:RecycleItemsView BackgroundColor="DeepPink"
                         Orientation="Vertical"
                         ScrollPolicy="MakeVisible"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -42,10 +42,10 @@
                 <tvcontrols:RecycleItemsView BackgroundColor="Coral"
                         Orientation="Vertical"
                         ScrollPolicy="Start"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>
@@ -58,10 +58,10 @@
                 <tvcontrols:RecycleItemsView BackgroundColor="Moccasin"
                         Orientation="Vertical"
                         ScrollPolicy="End"
-                        ContentMargin="100"
-                        ItemWidth="300"
-                        ItemHeight="200"
-                        Spacing="30"
+                        ContentMargin="200"
+                        ItemWidth="600"
+                        ItemHeight="400"
+                        Spacing="60"
                         ItemsSource="{Binding Items}">
                     <tvcontrols:RecycleItemsView.ItemTemplate>
                         <DataTemplate>

--- a/sample/Sample/RemoteControl/RemoteControlModels.cs
+++ b/sample/Sample/RemoteControl/RemoteControlModels.cs
@@ -44,7 +44,7 @@ namespace Sample
                 new RemoteControlTestModel("Remote Control Xaml test", typeof(TestRemoteControl_xaml)),
                 new RemoteControlTestModel("NavigationPage test", typeof(TestNavigationPage)),
                 new RemoteControlTestModel("TabbedPage test", typeof(TestTabbedPage)),
-                new RemoteControlTestModel("MasterDetailPage test", typeof(TestMasterDetailPage)),
+                new RemoteControlTestModel("FlyoutPage test", typeof(TestFlyoutPage)),
             };
         }
     }

--- a/sample/Sample/RemoteControl/TestFlyoutPage.xaml
+++ b/sample/Sample/RemoteControl/TestFlyoutPage.xaml
@@ -1,44 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<MasterDetailPage xmlns="http://xamarin.com/schemas/2014/forms"
+<FlyoutPage xmlns="http://xamarin.com/schemas/2014/forms"
                   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                   xmlns:uicontrols="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
-                  x:Class="Sample.TestMasterDetailPage"
+                  x:Class="Sample.TestFlyoutPage"
                   x:Name="rootPage"
-                  Title="MasterDetailPage"
-                  MasterBehavior="Popover"
+                  Title="FlyoutPage"
+                  FlyoutLayoutBehavior="Popover"
                   IsPresented="True">
     <uicontrols:InputEvents.EventHandlers>
-        <uicontrols:RemoteKeyHandler Command="{Binding MasterDetailPageHandler, Source={x:Reference rootPage}}"/>
+        <uicontrols:RemoteKeyHandler Command="{Binding FlyoutPageHandler, Source={x:Reference rootPage}}"/>
     </uicontrols:InputEvents.EventHandlers>
-    <MasterDetailPage.Master>
-        <ContentPage Title="Master Page" BackgroundColor="DarkOliveGreen">
+    <FlyoutPage.Flyout>
+        <ContentPage Title="Flyout Page" BackgroundColor="DarkOliveGreen">
             <ContentPage.Content>
                 <StackLayout>
-                    <Label x:Name="MasterLabel"/>
+                    <Label x:Name="FlyoutLabel"/>
                     <Button Text="Change behavior"
                     VerticalOptions="CenterAndExpand" 
                     HorizontalOptions="CenterAndExpand" Clicked="OnClicked" />
                 </StackLayout>
             </ContentPage.Content>
             <uicontrols:InputEvents.EventHandlers>
-                <uicontrols:RemoteKeyHandler Command="{Binding MasterPageHandler, Source={x:Reference rootPage}}"/>
+                <uicontrols:RemoteKeyHandler Command="{Binding FlyoutHandler, Source={x:Reference rootPage}}"/>
             </uicontrols:InputEvents.EventHandlers>
         </ContentPage>
-    </MasterDetailPage.Master>
-    <MasterDetailPage.Detail>
+    </FlyoutPage.Flyout>
+    <FlyoutPage.Detail>
         <ContentPage Title="Detail Page" BackgroundColor="Cornsilk">
             <ContentPage.Content>
                 <StackLayout>
                     <Label x:Name="DetailLabel" HorizontalOptions="End" TextColor="Black"/>
-                    <Button Text="ShowMaster"
+                    <Button Text="ShowFlyout"
                     VerticalOptions="CenterAndExpand" 
-                    HorizontalOptions="CenterAndExpand" Clicked="OnShowMaster"/>
+                    HorizontalOptions="CenterAndExpand" Clicked="OnShowFlyout"/>
                 </StackLayout>
             </ContentPage.Content>
             <uicontrols:InputEvents.EventHandlers>
                 <uicontrols:RemoteKeyHandler Command="{Binding DetailPageHandler, Source={x:Reference rootPage}}"/>
             </uicontrols:InputEvents.EventHandlers>
         </ContentPage>
-    </MasterDetailPage.Detail>
-    
-</MasterDetailPage>
+    </FlyoutPage.Detail>
+</FlyoutPage>

--- a/sample/Sample/RemoteControl/TestFlyoutPage.xaml.cs
+++ b/sample/Sample/RemoteControl/TestFlyoutPage.xaml.cs
@@ -22,27 +22,27 @@ using Tizen.TV.UIControls.Forms;
 namespace Sample
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-	public partial class TestMasterDetailPage : MasterDetailPage
+	public partial class TestFlyoutPage : FlyoutPage
 	{
-        public Command<RemoteControlKeyEventArgs> MasterDetailPageHandler
+        public Command<RemoteControlKeyEventArgs> FlyoutPageHandler
         {
             get
             {
                 return new Command<RemoteControlKeyEventArgs>((arg) =>
                 {
-                    Console.WriteLine("MasterDetailPage => arg.KeyType : {0} , arg.KeyName : {1}", arg.KeyType, arg.KeyName);
+                    Console.WriteLine("FlyoutPage => arg.KeyType : {0} , arg.KeyName : {1}", arg.KeyType, arg.KeyName);
                     Title = $"{arg.KeyName} was pressed";
                 });
             }
         }
 
-        public Command<RemoteControlKeyEventArgs> MasterPageHandler
+        public Command<RemoteControlKeyEventArgs> FlyoutHandler
         {
             get
             {
                 return new Command<RemoteControlKeyEventArgs>((arg) => {
-                    Console.WriteLine("Master Page => arg.KeyType : {0} , arg.KeyName : {1}", arg.KeyType, arg.KeyName);
-                    MasterLabel.Text = $"{arg.KeyName} was pressed";
+                    Console.WriteLine("Flyout => arg.KeyType : {0} , arg.KeyName : {1}", arg.KeyType, arg.KeyName);
+                    FlyoutLabel.Text = $"{arg.KeyName} was pressed";
                 });
             }
         }
@@ -59,20 +59,20 @@ namespace Sample
             }
         }
 
-        public TestMasterDetailPage ()
+        public TestFlyoutPage()
 		{
 			InitializeComponent ();
 		}
 
         void OnClicked(object sender, EventArgs e)
         {
-            if (MasterBehavior == MasterBehavior.Popover)
-                MasterBehavior = MasterBehavior.Split;
+            if (FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover)
+                FlyoutLayoutBehavior = FlyoutLayoutBehavior.Split;
             else
-                MasterBehavior = MasterBehavior.Popover;
+                FlyoutLayoutBehavior = FlyoutLayoutBehavior.Popover;
         }
 
-        void OnShowMaster(object sender, EventArgs e)
+        void OnShowFlyout(object sender, EventArgs e)
         {
             IsPresented = true;
         }

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -6,7 +6,7 @@
 
   <!-- Include Nuget Package for Xamarin building -->
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1558-pre3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Tizen.TV.UIControls.Forms\Tizen.TV.UIControls.Forms.csproj" />
@@ -32,6 +32,9 @@
     </Compile>
     <Compile Update="RecycleItemsView\ItemFocusedEventTest.xaml.cs">
       <DependentUpon>ItemFocusedEventTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="RemoteControl\TestFlyoutPage.xaml.cs">
+      <DependentUpon>TestFlyoutPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -107,7 +110,7 @@
     <EmbeddedResource Update="RemoteControl\RemoteControlMainPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-    <EmbeddedResource Update="RemoteControl\TestMasterDetailPage.xaml">
+    <EmbeddedResource Update="RemoteControl\TestFlyoutPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Update="RemoteControl\TestRemoteControl_xaml.xaml">

--- a/sample/TMDb/src/TMDb/TMDb.Tizen/TMDb.Tizen.cs
+++ b/sample/TMDb/src/TMDb/TMDb.Tizen/TMDb.Tizen.cs
@@ -9,16 +9,20 @@ namespace TMDb
         protected override void OnCreate()
         {
             base.OnCreate();
-            Tizen.TV.UIControls.Forms.UIControls.MainWindowProvider = () => MainWindow;
             LoadApplication(new App());
         }
 
         static void Main(string[] args)
         {
             var app = new Program();
+            var option = new InitializationOptions(app)
+            {
+                DisplayResolutionUnit = DisplayResolutionUnit.Pixel()
+            };
+            Forms.Init(option);
+            // UIControls.Init() should be called after Forms.Init()
+            UIControls.Init(new InitOptions(app));
             FFImageLoading.Forms.Platform.CachedImageRenderer.Init(app);
-            UIControls.Init();
-            Forms.Init(app);
             app.Run(args);
         }
     }

--- a/sample/TMDb/src/TMDb/TMDb/CastListView.xaml
+++ b/sample/TMDb/src/TMDb/TMDb/CastListView.xaml
@@ -12,7 +12,7 @@
     </ContentView.Resources>
     <ContentView.Content>
         <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="Center">
-            <Label Margin="30,0,0,0" FontSize="90" TextColor="#e0e0e0" Text="Cast" FontAttributes="Bold"/>
+            <Label Margin="30,0,0,0" FontSize="45" TextColor="#e0e0e0" Text="Cast" FontAttributes="Bold"/>
             <tv:RecycleItemsView ContentMargin="100, 50, 100, 50" Spacing="60" ItemHeight="300" ItemWidth="250"
                                  ItemsSource="{Binding Items}">
                 <tv:RecycleItemsView.ItemTemplate>
@@ -22,7 +22,7 @@
                             <StackLayout Padding="0" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All" Orientation="Vertical">
                                 <StackLayout VerticalOptions="FillAndExpand"/>
                                 <StackLayout Padding="20" HorizontalOptions="FillAndExpand" BackgroundColor="#aa000000">
-                                    <Label Text="{Binding Name}" TextColor="#e0e0e0" FontSize="50" FontAttributes="Bold" />
+                                    <Label Text="{Binding Name}" TextColor="#e0e0e0" FontSize="25" FontAttributes="Bold" />
                                 </StackLayout>
                             </StackLayout>
                         </AbsoluteLayout>

--- a/sample/TMDb/src/TMDb/TMDb/DetailPage.xaml
+++ b/sample/TMDb/src/TMDb/TMDb/DetailPage.xaml
@@ -26,7 +26,7 @@
                         <ff:CachedImage Margin="50" Source="{Binding PosterPath, Converter={StaticResource posterConverter}}"/>
                         <StackLayout Margin="50" Spacing="10" WidthRequest="1000" HorizontalOptions="End" Opacity="1.0">
                             <Label FontSize="Large" Text="{Binding Title}" FontAttributes="Bold"/>
-                            <Label FontSize="70" Text="Overview" FontAttributes="Bold"/>
+                            <Label FontSize="35" Text="Overview" FontAttributes="Bold"/>
                             <Label FontSize="Medium" Text="{Binding Overview}"/>
                         </StackLayout>
                     </StackLayout>

--- a/sample/TMDb/src/TMDb/TMDb/MainPage.xaml
+++ b/sample/TMDb/src/TMDb/TMDb/MainPage.xaml
@@ -37,7 +37,7 @@
                                            VerticalOptions="FillAndExpand"
                                            VerticalTextAlignment="Center"
                                            Text="{Binding Text}" TextColor="#e0e0e0"
-                                           FontSize="80" FontAttributes="Bold"/>
+                                           FontSize="40" FontAttributes="Bold"/>
                                     </StackLayout>
                                 </DataTemplate>
                             </local:MenuItemsView.ItemTemplate>

--- a/sample/TMDb/src/TMDb/TMDb/PosterListView.xaml
+++ b/sample/TMDb/src/TMDb/TMDb/PosterListView.xaml
@@ -12,7 +12,7 @@
   </ContentView.Resources>
   <ContentView.Content>
         <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="Center">
-            <Label Margin="30,0,0,0" FontSize="90" TextColor="#e0e0e0" Text="{Binding Title}" FontAttributes="Bold"/>
+            <Label Margin="30,0,0,0" FontSize="45" TextColor="#e0e0e0" Text="{Binding Title}" FontAttributes="Bold"/>
             <tv:RecycleItemsView x:Name="ItemsView" ContentMargin="100, 50, 100, 50" Spacing="60"
                                  ItemsSource="{Binding Items}"
                                  ItemSelected="RecycleItemsView_ItemSelected">
@@ -23,8 +23,8 @@
                             <StackLayout Padding="0" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All" Orientation="Vertical">
                                 <StackLayout VerticalOptions="FillAndExpand"/>
                                 <StackLayout Padding="30" HorizontalOptions="FillAndExpand" BackgroundColor="#aa000000">
-                                    <Label Text="{Binding Title}" TextColor="#e0e0e0" FontSize="70" FontAttributes="Bold" />
-                                    <Label Text="{Binding VoteAverage, StringFormat='Rating {0}'}" TextColor="#e0e0e0" FontSize="50" FontAttributes="Bold" />
+                                    <Label Text="{Binding Title}" TextColor="#e0e0e0" FontSize="35" FontAttributes="Bold" />
+                                    <Label Text="{Binding VoteAverage, StringFormat='Rating {0}'}" TextColor="#e0e0e0" FontSize="25" FontAttributes="Bold" />
                                 </StackLayout>
                             </StackLayout>
                         </AbsoluteLayout>

--- a/sample/TMDb/src/TMDb/TMDb/TMDb.csproj
+++ b/sample/TMDb/src/TMDb/TMDb/TMDb.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
     <PackageReference Include="TMDbLib" Version="1.2.0-alpha" />
     <PackageReference Include="Xamarin.FFImageLoading.Forms" Version="2.4.3.840" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1558-pre3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Tizen.TV.UIControls.Forms\Tizen.TV.UIControls.Forms.csproj" />

--- a/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
+++ b/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
@@ -730,6 +730,7 @@ namespace Tizen.TV.UIControls.Forms
             if (isFocused && data == FocusedItem)
             {
                 var item = GetItemContext(data);
+                if (item == null) return;
                 if (item.IsRealized && item.RealizedView == targetView)
                     SetValue(FocusedViewPropertyKey, targetView);
             }

--- a/src/Tizen.TV.UIControls.Forms/Renderer/AccessKeyEffect.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/AccessKeyEffect.cs
@@ -92,7 +92,23 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                     return true;
             }
 
+            if (pageToCompare is FlyoutPage flyoutPage)
+            {
+                if (flyoutPage.IsPresented)
+                {
+                    if (IsOnCurrentPage(flyoutPage.Flyout, targetPage))
+                        return true;
+                }
+                if (!(flyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover && flyoutPage.IsPresented))
+                {
+                    if (IsOnCurrentPage(flyoutPage.Detail, targetPage))
+                        return true;
+                }
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
             if (pageToCompare is MasterDetailPage masterDetailPage)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 if (masterDetailPage.IsPresented)
                 {

--- a/src/Tizen.TV.UIControls.Forms/Renderer/RemoteKeyEventEffect.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/RemoteKeyEventEffect.cs
@@ -126,7 +126,23 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                     return true;
             }
 
+            if (pageToCompare is FlyoutPage flyoutPage)
+            {
+                if (flyoutPage.IsPresented)
+                {
+                    if (IsOnCurrentPage(flyoutPage.Flyout, targetPage))
+                        return true;
+                }
+                if (!(flyoutPage.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Popover && flyoutPage.IsPresented))
+                {
+                    if (IsOnCurrentPage(flyoutPage.Detail, targetPage))
+                        return true;
+                }
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
             if (pageToCompare is MasterDetailPage masterDetailPage)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 if (masterDetailPage.IsPresented)
                 {

--- a/src/Tizen.TV.UIControls.Forms/Tizen.TV.UIControls.Forms.csproj
+++ b/src/Tizen.TV.UIControls.Forms/Tizen.TV.UIControls.Forms.csproj
@@ -21,7 +21,7 @@
     <None Remove="Resources\img_button_play.png" />
     <EmbeddedResource Include="Resources\img_button_pause.png" />
     <EmbeddedResource Include="Resources\img_button_play.png" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1364" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1558-pre3" />
     <EmbeddedResource Update="EmbeddingControls.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>


### PR DESCRIPTION
### Description of Change ###
This PR is to update the Xamarin.Forms version to 5.0.0-pre3. Accordingly, the samples were also changed. 

The major changes in the sample apps (both `Sample` and `TMDB`) are as follows.

- Use `FlyoutPage` instead of `MasterDetailPage`
- Use `DP` as a DisplayResolutionUnit (Previously, `Pixel`)
  - `TMDB` keeps using `Pixel`
- Font size modification due to font scaling modification
- TV UI Opt-in Init applied
- Removes all warnings on build
- Other minor bug fixes

### Bugs Fixed ###
- None

### API Changes ###
None

### Behavioral Changes ###
None
