### PR TITLE
Fix default focused item index on RecycleItemsView

### DIFF
--- a/sample/Sample/RecycleItemsView/FocusOnHeaderTest.xaml
+++ b/sample/Sample/RecycleItemsView/FocusOnHeaderTest.xaml
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             NavigationPage.HasNavigationBar="False"
+             x:Class="Sample.RecycleItemsView.FocusOnHeaderTest">
+    <ContentPage.Content>
+        <StackLayout HorizontalOptions="FillAndExpand" VerticalOptions="Center">
+            <Label Text="Focus on header" FontAttributes="Bold" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Start" FontSize="Large"/>
+            <tv:RecycleItemsView x:Name="MovieList" HorizontalOptions="FillAndExpand" BackgroundColor="Brown" HeightRequest="1000"
+                    ScrollBarVisibility="Never"
+                    ContentMargin="200"
+                    ItemWidth="960"
+                    Spacing="100"
+                    ItemsSource="{Binding Items}">
+                <tv:RecycleItemsView.ItemTemplate>
+                    <DataTemplate>
+                        <AbsoluteLayout BackgroundColor="CadetBlue">
+                            <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
+                            <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                                <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
+                                <Label Text="{Binding DetailText}" FontSize="40"/>
+                            </StackLayout>
+                        </AbsoluteLayout>
+                    </DataTemplate>
+                </tv:RecycleItemsView.ItemTemplate>
+            </tv:RecycleItemsView>
+            <tv:RecycleItemsView x:Name="MusicList" HorizontalOptions="FillAndExpand" BackgroundColor="Beige"
+                    ContentMargin="200"
+                    ItemWidth="800"
+                    ItemHeight="800"
+                    Spacing="60"
+                    Header="Header"
+                    Footer="More"
+                    ItemsSource="{Binding Items2}">
+                <tv:RecycleItemsView.ItemTemplate>
+                    <DataTemplate>
+                        <ImageCell ImageSource="{Binding Source}" Text="{Binding Text}" Detail="{Binding DetailText}"/>
+                    </DataTemplate>
+                </tv:RecycleItemsView.ItemTemplate>
+                <tv:RecycleItemsView.HeaderTemplate>
+                    <DataTemplate>
+                        <StackLayout WidthRequest="600" Padding="40" BackgroundColor="#5b6b72">
+                            <Image Source="img_profile_c.png" HorizontalOptions="Center" VerticalOptions="CenterAndExpand" WidthRequest="200" HeightRequest="400"/>
+                            <Label Text="Haeder" TextColor="AntiqueWhite" FontAttributes="Bold" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </tv:RecycleItemsView.HeaderTemplate>
+                <tv:RecycleItemsView.FooterTemplate>
+                    <DataTemplate>
+                        <StackLayout WidthRequest="600" Padding="40" BackgroundColor="#5b6b72">
+                            <Image Source="img_profile_c.png" HorizontalOptions="Center" VerticalOptions="CenterAndExpand" WidthRequest="200" HeightRequest="400"/>
+                            <Label Text="Music" TextColor="AntiqueWhite" FontAttributes="Bold" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </tv:RecycleItemsView.FooterTemplate>
+            </tv:RecycleItemsView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/sample/Sample/RecycleItemsView/FocusOnHeaderTest.xaml.cs
+++ b/sample/Sample/RecycleItemsView/FocusOnHeaderTest.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Sample.RecycleItemsView
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class FocusOnHeaderTest : ContentPage
+    {
+        public FocusOnHeaderTest()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/sample/Sample/RecycleItemsView/RecycleItemsViewModel.cs
+++ b/sample/Sample/RecycleItemsView/RecycleItemsViewModel.cs
@@ -117,6 +117,13 @@ namespace Sample.RecycleItemsView
                     PageType = typeof(ItemFocusedEventTest),
                     Items = ColorModel.MakeModel()
                 },
+                new DoubleItemsModel
+                {
+                    Name = "FocusOnHeader",
+                    PageType = typeof(FocusOnHeaderTest),
+                    Items = PosterModel.MakeModel(),
+                    Items2 = PosterModel.MakeAlbumArtsModel(),
+                },
             };
         }
     }

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -104,6 +104,9 @@
     <EmbeddedResource Update="RecycleItemsView\FocusChainTest.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="RecycleItemsView\FocusOnHeaderTest.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="RecycleItemsView\HeaderTest.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
+++ b/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
@@ -1142,13 +1142,25 @@ namespace Tizen.TV.UIControls.Forms
         {
             if (e.IsFocused && ItemsCount > 0)
             {
-                if (FocusedItemIndex == InvalidIndex ||
-                    (FocusedItemIndex == HeaderIndex && (!AllowFocusHeader || !HasHeader)) ||
-                    (FocusedItemIndex == FooterIndex && (!AllowFocusFooter || !HasFooter)))
+                if (FocusedItemIndex == InvalidIndex)
+                {
+                    if (AllowFocusHeader && HasHeader)
+                        FocusedItemIndex = HeaderIndex;
+                    else
+                        FocusedItemIndex = 0;
+                }
+                else if (FocusedItemIndex >= ItemsCount)
+                {
+                    if (AllowFocusFooter && HasFooter)
+                        FocusedItemIndex = FooterIndex;
+                    else
+                        FocusedItemIndex = ItemsCount - 1;
+                }
+                else if (FocusedItemIndex == HeaderIndex && (!AllowFocusHeader || !HasHeader))
                 {
                     FocusedItemIndex = 0;
                 }
-                else if (FocusedItemIndex >= ItemsCount)
+                else if (FocusedItemIndex == FooterIndex && (!AllowFocusFooter || !HasFooter))
                 {
                     FocusedItemIndex = ItemsCount - 1;
                 }


### PR DESCRIPTION
### Description of Change ###
This PR fix a default FocusedItemIndex that changed from invalid value


### Bugs Fixed ###
- If has a header and it could be focused, it should be a first focused item on RecycleItemsView, but was not


### API Changes ###
None

### Behavioral Changes ###
A first focused item is header if header could be got a focus

![default-focus](https://user-images.githubusercontent.com/1029155/98502480-71398a80-2295-11eb-8ee7-e604fefe852a.gif)
