### PR TITLE
Update FocusFrame to handle focused event on descendants view

### DIFF
--- a/sample/Sample/Focus/FocusFrameScrollTest.xaml
+++ b/sample/Sample/Focus/FocusFrameScrollTest.xaml
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             xmlns:local="clr-namespace:Sample.Focus"
+             NavigationPage.HasNavigationBar="False"
+             x:Class="Sample.Focus.FocusFrameScrollTest">
+    <ContentPage.Content>
+        <ScrollView>
+            <StackLayout>
+                <Label Text="Title1" FontSize="90"/>
+                <local:ScrollFocusFrame>
+                    <tv:RecycleItemsView HeightRequest="900" ItemsSource="{Binding Items}" ScrollPolicy="Center"
+                                         ItemWidth="900" ContentMargin="200" Spacing="200">
+                        <tv:RecycleItemsView.ItemTemplate>
+                            <DataTemplate>
+                                <AbsoluteLayout BackgroundColor="CadetBlue">
+                                    <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
+                                    <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                                        <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
+                                        <Label Text="{Binding DetailText}" FontSize="40"/>
+                                    </StackLayout>
+                                </AbsoluteLayout>
+                            </DataTemplate>
+                        </tv:RecycleItemsView.ItemTemplate>
+                    </tv:RecycleItemsView>
+                </local:ScrollFocusFrame>
+                <Label Text="Title2" FontSize="90"/>
+                <local:ScrollFocusFrame>
+                    <tv:RecycleItemsView HeightRequest="900" ItemsSource="{Binding Items}" ScrollPolicy="Center"
+                                         ItemWidth="900" ContentMargin="200" Spacing="200">
+                        <tv:RecycleItemsView.ItemTemplate>
+                            <DataTemplate>
+                                <AbsoluteLayout BackgroundColor="CadetBlue">
+                                    <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
+                                    <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                                        <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
+                                        <Label Text="{Binding DetailText}" FontSize="40"/>
+                                    </StackLayout>
+                                </AbsoluteLayout>
+                            </DataTemplate>
+                        </tv:RecycleItemsView.ItemTemplate>
+                    </tv:RecycleItemsView>
+                </local:ScrollFocusFrame>
+                <Label Text="Title3" FontSize="90"/>
+                <local:ScrollFocusFrame>
+                    <tv:RecycleItemsView HeightRequest="900" ItemsSource="{Binding Items}" ScrollPolicy="Center"
+                                         ItemWidth="900" ContentMargin="200" Spacing="200">
+                        <tv:RecycleItemsView.ItemTemplate>
+                            <DataTemplate>
+                                <AbsoluteLayout BackgroundColor="CadetBlue">
+                                    <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
+                                    <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                                        <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
+                                        <Label Text="{Binding DetailText}" FontSize="40"/>
+                                    </StackLayout>
+                                </AbsoluteLayout>
+                            </DataTemplate>
+                        </tv:RecycleItemsView.ItemTemplate>
+                    </tv:RecycleItemsView>
+                </local:ScrollFocusFrame>
+                <Label Text="Title4" FontSize="90"/>
+                <local:ScrollFocusFrame>
+                    <tv:RecycleItemsView HeightRequest="900" ItemsSource="{Binding Items}" ScrollPolicy="Center"
+                                         ItemWidth="900" ContentMargin="200" Spacing="200">
+                        <tv:RecycleItemsView.ItemTemplate>
+                            <DataTemplate>
+                                <AbsoluteLayout BackgroundColor="CadetBlue">
+                                    <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
+                                    <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                                        <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
+                                        <Label Text="{Binding DetailText}" FontSize="40"/>
+                                    </StackLayout>
+                                </AbsoluteLayout>
+                            </DataTemplate>
+                        </tv:RecycleItemsView.ItemTemplate>
+                    </tv:RecycleItemsView>
+                </local:ScrollFocusFrame>
+                <Label Text="Title5" FontSize="90"/>
+                <local:ScrollFocusFrame>
+                    <tv:RecycleItemsView HeightRequest="900" ItemsSource="{Binding Items}" ScrollPolicy="Center"
+                                         ItemWidth="900" ContentMargin="200" Spacing="200">
+                        <tv:RecycleItemsView.ItemTemplate>
+                            <DataTemplate>
+                                <AbsoluteLayout BackgroundColor="CadetBlue">
+                                    <Image Source="{Binding Source}" Aspect="Fill" AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="All"/>
+                                    <StackLayout Padding="40" AbsoluteLayout.LayoutBounds="0, 1, 960, 200" AbsoluteLayout.LayoutFlags="PositionProportional" BackgroundColor="#aa000000">
+                                        <Label Text="{Binding Text}" TextColor="AntiqueWhite" FontSize="70" FontAttributes="Bold" />
+                                        <Label Text="{Binding DetailText}" FontSize="40"/>
+                                    </StackLayout>
+                                </AbsoluteLayout>
+                            </DataTemplate>
+                        </tv:RecycleItemsView.ItemTemplate>
+                    </tv:RecycleItemsView>
+                </local:ScrollFocusFrame>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/sample/Sample/Focus/FocusFrameScrollTest.xaml.cs
+++ b/sample/Sample/Focus/FocusFrameScrollTest.xaml.cs
@@ -1,0 +1,39 @@
+using Tizen.TV.UIControls.Forms;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Sample.Focus
+{
+
+    class ScrollFocusFrame : FocusFrame
+    {
+        protected override void OnContentFocused(bool isFocused)
+        {
+            if (isFocused)
+            {
+                var element = Parent;
+                while (element != null)
+                {
+                    if (element is ScrollView scrollview)
+                    {
+                        Device.BeginInvokeOnMainThread(() =>
+                        {
+                            scrollview.ScrollToAsync(this, ScrollToPosition.Center, true);
+                        });
+                        return;
+                    }
+                    element = element.Parent;
+                }
+            }
+        }
+    }
+
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class FocusFrameScrollTest : ContentPage
+    {
+        public FocusFrameScrollTest()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/sample/Sample/Focus/FocusFrameTest.xaml
+++ b/sample/Sample/Focus/FocusFrameTest.xaml
@@ -6,7 +6,7 @@
              Title="Focus navigation"
              x:Class="Sample.Focus.FocusFrameTest">
     <ContentPage.Content>
-        <Grid RowDefinitions="100, 100, 100, *"
+        <Grid RowDefinitions="*, *, *, *"
               ColumnDefinitions="*, *, *, *">
             <tv:FocusFrame Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
                 <Entry Placeholder="Entry1" />
@@ -38,7 +38,13 @@
                 <Button Text="3"/>
             </local:MyFocusFrame>
             <tv:FocusFrame Grid.Row="2" Grid.Column="3">
-                <Button Text="4"/>
+                <ScrollView>
+                    <StackLayout x:Name="AddedContainer">
+                        <Label Text="Text1"/>
+                        <Button Text="Add" Clicked="OnAddedClicked"/>
+                        <Label Text="Text2"/>
+                    </StackLayout>
+                </ScrollView>
             </tv:FocusFrame>
         </Grid>
     </ContentPage.Content>

--- a/sample/Sample/Focus/FocusFrameTest.xaml
+++ b/sample/Sample/Focus/FocusFrameTest.xaml
@@ -15,7 +15,7 @@
                 <Entry Placeholder="Entry2" />
             </tv:FocusFrame>
 
-            <tv:FocusFrame Grid.Row="1" Grid.Column="0">
+            <tv:FocusFrame Grid.Row="1" Grid.Column="0" UnfocusedColor="Gray">
                 <CheckBox/>
             </tv:FocusFrame>
             <tv:FocusFrame FocusedColor="Yellow" Grid.Row="1" Grid.Column="1">

--- a/sample/Sample/Focus/FocusFrameTest.xaml
+++ b/sample/Sample/Focus/FocusFrameTest.xaml
@@ -46,6 +46,16 @@
                     </StackLayout>
                 </ScrollView>
             </tv:FocusFrame>
+            <tv:FocusFrame x:Name="_focsusFrame1" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4" ContentFocused="OnContentFocused">
+                <StackLayout>
+                    <Label x:Name="FocusedItemLabel" Text="Focused Item : "/>
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="btn" HorizontalOptions="FillAndExpand"/>
+                        <CheckBox HorizontalOptions="CenterAndExpand"/>
+                        <Entry HorizontalOptions="CenterAndExpand"/>
+                    </StackLayout>
+                </StackLayout>
+            </tv:FocusFrame>
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/sample/Sample/Focus/FocusFrameTest.xaml.cs
+++ b/sample/Sample/Focus/FocusFrameTest.xaml.cs
@@ -10,6 +10,10 @@ namespace Sample.Focus
         public FocusFrameTest()
         {
             InitializeComponent();
+            _focsusFrame1.ContentUnfocusedCommand = new Command(() =>
+            {
+                FocusedItemLabel.Text = $"Focused Item : ";
+            });
         }
 
         int id = 0;
@@ -25,6 +29,11 @@ namespace Sample.Focus
                 AddedContainer.Children.Remove(addedBtn);
             };
             AddedContainer.Children.Add(addedBtn);
+        }
+
+        void OnContentFocused(object sender, FocusEventArgs e)
+        {
+            FocusedItemLabel.Text = $"Focused Item : {e.VisualElement}";
         }
     }
 

--- a/sample/Sample/Focus/FocusFrameTest.xaml.cs
+++ b/sample/Sample/Focus/FocusFrameTest.xaml.cs
@@ -11,6 +11,21 @@ namespace Sample.Focus
         {
             InitializeComponent();
         }
+
+        int id = 0;
+
+        void OnAddedClicked(object sender, System.EventArgs e)
+        {
+            var addedBtn = new Button
+            {
+                Text = $"Remove({id++})"
+            };
+            addedBtn.Clicked += (s, evt) =>
+            {
+                AddedContainer.Children.Remove(addedBtn);
+            };
+            AddedContainer.Children.Add(addedBtn);
+        }
     }
 
     public class MyFocusFrame : FocusFrame

--- a/sample/Sample/Focus/FocusTestModel.cs
+++ b/sample/Sample/Focus/FocusTestModel.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Sample.Focus
@@ -23,6 +24,11 @@ namespace Sample.Focus
     {
         public string Name { get; set; }
         public Type PageType { get; set; }
+    }
+
+    class ItemsTestModel : TestModel
+    {
+        public IList Items { get; set; }
     }
 
     class FocusTestModel
@@ -56,6 +62,12 @@ namespace Sample.Focus
                 {
                     Name = "Focus Frame",
                     PageType = typeof(FocusFrameTest)
+                },
+                new ItemsTestModel
+                {
+                    Name = "Focus Frame Scroll test",
+                    PageType = typeof(FocusFrameScrollTest),
+                    Items = RecycleItemsView.PosterModel.MakeModel()
                 }
             };
         }

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -59,6 +59,9 @@
     <EmbeddedResource Update="Focus\FocusBasicTest.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Focus\FocusFrameScrollTest.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Focus\FocusMainPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -32,6 +32,11 @@ namespace Tizen.TV.UIControls.Forms
         public static readonly BindableProperty FocusedColorProperty = BindableProperty.Create(nameof(FocusedColor), typeof(Color), typeof(FocusFrame), Color.Orange);
 
         /// <summary>
+        /// Identifies the UnfocusedColor bindable property.
+        /// </summary>
+        public static readonly BindableProperty UnfocusedColorProperty = BindableProperty.Create(nameof(UnfocusedColor), typeof(Color), typeof(FocusFrame), Color.Transparent);
+
+        /// <summary>
         /// Identifies the ContentFocusedCommand bindable property
         /// </summary>
         public static readonly BindableProperty ContentFocusedCommandProperty = BindableProperty.Create(nameof(ContentFocusedCommand), typeof(ICommand), typeof(FocusFrame), null);
@@ -117,6 +122,15 @@ namespace Tizen.TV.UIControls.Forms
             set => SetValue(FocusedColorProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets a value that represents UnfocusedColor, it used for decorating unfocused state on content
+        /// </summary>
+        public Color UnfocusedColor
+        {
+            get => (Color)GetValue(UnfocusedColorProperty);
+            set => SetValue(UnfocusedColorProperty, value);
+        }
+
         protected override void OnPropertyChanging([CallerMemberName] string propertyName = null)
         {
             base.OnPropertyChanging(propertyName);
@@ -172,7 +186,7 @@ namespace Tizen.TV.UIControls.Forms
         /// <param name="isFocused">This parameter indicates whether the content is focused.</param>
         protected virtual void OnContentFocused(bool isFocused)
         {
-            BackgroundColor = isFocused ? FocusedColor : Color.Transparent;
+            BackgroundColor = isFocused ? FocusedColor : UnfocusedColor;
         }
 
         void OnContentFocused(object sender, FocusEventArgs e)

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -58,6 +58,17 @@ namespace Tizen.TV.UIControls.Forms
                 {
                     Content.Focused -= OnContentFocused;
                     Content.Unfocused -= OnContentFocused;
+                    Content.DescendantAdded -= OnDescendantAdded;
+                    Content.DescendantRemoved -= OnDescendantRemoved;
+
+                    foreach (var child in Content.Descendants())
+                    {
+                        if (child is VisualElement ve)
+                        {
+                            ve.Focused -= OnContentFocused;
+                            ve.Unfocused -= OnContentFocused;
+                        }
+                    }
                 }
             }
         }
@@ -71,6 +82,17 @@ namespace Tizen.TV.UIControls.Forms
                 {
                     Content.Focused += OnContentFocused;
                     Content.Unfocused += OnContentFocused;
+                    Content.DescendantAdded += OnDescendantAdded;
+                    Content.DescendantRemoved += OnDescendantRemoved;
+
+                    foreach (var child in Content.Descendants())
+                    {
+                        if (child is VisualElement ve)
+                        {
+                            ve.Focused += OnContentFocused;
+                            ve.Unfocused += OnContentFocused;
+                        }
+                    }
                 }
             }
         }
@@ -89,5 +111,24 @@ namespace Tizen.TV.UIControls.Forms
         {
             OnContentFocused(e.IsFocused);
         }
+
+        void OnDescendantAdded(object sender, ElementEventArgs e)
+        {
+            if (e.Element is VisualElement ve)
+            {
+                ve.Focused += OnContentFocused;
+                ve.Unfocused += OnContentFocused;
+            }
+        }
+
+        void OnDescendantRemoved(object sender, ElementEventArgs e)
+        {
+            if (e.Element is VisualElement ve)
+            {
+                ve.Focused -= OnContentFocused;
+                ve.Unfocused -= OnContentFocused;
+            }
+        }
+
     }
 }

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -29,12 +29,12 @@ namespace Tizen.TV.UIControls.Forms
         /// <summary>
         /// Identifies the FocusedColor bindable property.
         /// </summary>
-        public static readonly BindableProperty FocusedColorProperty = BindableProperty.Create(nameof(FocusedColor), typeof(Color), typeof(FocusFrame), Color.Orange);
+        public static readonly BindableProperty FocusedColorProperty = BindableProperty.Create(nameof(FocusedColor), typeof(Color), typeof(FocusFrame), Color.Orange, propertyChanged: (b, o, n) => (b as FocusFrame).OnContentFocused());
 
         /// <summary>
         /// Identifies the UnfocusedColor bindable property.
         /// </summary>
-        public static readonly BindableProperty UnfocusedColorProperty = BindableProperty.Create(nameof(UnfocusedColor), typeof(Color), typeof(FocusFrame), Color.Transparent);
+        public static readonly BindableProperty UnfocusedColorProperty = BindableProperty.Create(nameof(UnfocusedColor), typeof(Color), typeof(FocusFrame), Color.Transparent, propertyChanged: (b, o, n) => (b as FocusFrame).OnContentFocused());
 
         /// <summary>
         /// Identifies the ContentFocusedCommand bindable property
@@ -55,6 +55,13 @@ namespace Tizen.TV.UIControls.Forms
         /// Identifies the ContentUnfocusedCommandParameter bindable property
         /// </summary>
         public static readonly BindableProperty ContentUnfocusedCommandParameterProperty = BindableProperty.Create(nameof(ContentUnfocusedCommandParameter), typeof(object), typeof(FocusFrame), null);
+
+        static readonly BindablePropertyKey IsContentFocusedPropertyKey = BindableProperty.CreateReadOnly(nameof(IsContentFocused), typeof(bool), typeof(FocusFrame), false, propertyChanged: (b, o, n) => (b as FocusFrame).UpdateIsContentFocused());
+
+        /// <summary>
+        /// Identifies the IsContentFocused bindable property.
+        /// </summary>
+        public static readonly BindableProperty IsContentFocusedProperty = IsContentFocusedPropertyKey.BindableProperty;
 
         /// <summary>
         /// Creates and initializes a new instance of the FocusFrame class.
@@ -131,6 +138,15 @@ namespace Tizen.TV.UIControls.Forms
             set => SetValue(UnfocusedColorProperty, value);
         }
 
+        /// <summary>
+        /// Gets a value indicating whether content is focused currently.
+        /// </summary>
+        public bool IsContentFocused
+        {
+            get => (bool)GetValue(IsContentFocusedProperty);
+            private set => SetValue(IsContentFocusedPropertyKey, value);
+        }
+
         protected override void OnPropertyChanging([CallerMemberName] string propertyName = null)
         {
             base.OnPropertyChanging(propertyName);
@@ -191,18 +207,31 @@ namespace Tizen.TV.UIControls.Forms
 
         void OnContentFocused(object sender, FocusEventArgs e)
         {
-            OnContentFocused(e.IsFocused);
+            IsContentFocused = e.IsFocused;
             if (e.IsFocused)
             {
-                ContentFocusedCommand?.Execute(ContentFocusedCommandParameter);
                 ContentFocused?.Invoke(this, e);
             }
             else
             {
-                ContentUnfocusedCommand?.Execute(ContentUnfocusedCommandParameter);
                 ContentUnfocused?.Invoke(this, e);
             }
         }
+
+        void OnContentFocused()
+        {
+            OnContentFocused(IsContentFocused);
+        }
+
+        void UpdateIsContentFocused()
+        {
+            OnContentFocused(IsContentFocused);
+            if (IsContentFocused)
+                ContentFocusedCommand?.Execute(ContentFocusedCommandParameter);
+            else
+                ContentUnfocusedCommand?.Execute(ContentUnfocusedCommandParameter);
+        }
+
 
         void OnDescendantAdded(object sender, ElementEventArgs e)
         {

--- a/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
+++ b/src/Tizen.TV.UIControls.Forms/FocusFrame.cs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+using System;
 using System.Runtime.CompilerServices;
+using System.Windows.Input;
 using Xamarin.Forms;
 
 namespace Tizen.TV.UIControls.Forms
@@ -29,6 +31,25 @@ namespace Tizen.TV.UIControls.Forms
         /// </summary>
         public static readonly BindableProperty FocusedColorProperty = BindableProperty.Create(nameof(FocusedColor), typeof(Color), typeof(FocusFrame), Color.Orange);
 
+        /// <summary>
+        /// Identifies the ContentFocusedCommand bindable property
+        /// </summary>
+        public static readonly BindableProperty ContentFocusedCommandProperty = BindableProperty.Create(nameof(ContentFocusedCommand), typeof(ICommand), typeof(FocusFrame), null);
+
+        /// <summary>
+        /// Identifies the ContentFocusedCommandParameter bindable property
+        /// </summary>
+        public static readonly BindableProperty ContentFocusedCommandParameterProperty = BindableProperty.Create(nameof(ContentFocusedCommandParameter), typeof(object), typeof(FocusFrame), null);
+
+        /// <summary>
+        /// Identifies the ContentUnfocusedCommand bindable property
+        /// </summary>
+        public static readonly BindableProperty ContentUnfocusedCommandProperty = BindableProperty.Create(nameof(ContentUnfocusedCommand), typeof(ICommand), typeof(FocusFrame), null);
+
+        /// <summary>
+        /// Identifies the ContentUnfocusedCommandParameter bindable property
+        /// </summary>
+        public static readonly BindableProperty ContentUnfocusedCommandParameterProperty = BindableProperty.Create(nameof(ContentUnfocusedCommandParameter), typeof(object), typeof(FocusFrame), null);
 
         /// <summary>
         /// Creates and initializes a new instance of the FocusFrame class.
@@ -38,6 +59,53 @@ namespace Tizen.TV.UIControls.Forms
             Padding = 10;
             BorderColor = Color.Transparent;
             HasShadow = false;
+        }
+
+        /// <summary>
+        /// Raise when one of descendants view are focused
+        /// </summary>
+        public event EventHandler<FocusEventArgs> ContentFocused;
+
+        /// <summary>
+        /// Raise when one of descendants view are unfocused
+        /// </summary>
+        public event EventHandler<FocusEventArgs> ContentUnfocused;
+
+
+        /// <summary>
+        /// Gets or sets the command to invoke when the content is focused. This is a bindable property.
+        /// </summary>
+        public ICommand ContentFocusedCommand
+        {
+            get => (ICommand)GetValue(ContentFocusedCommandProperty);
+            set => SetValue(ContentFocusedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the parameter to pass to the ContentFocusedCommand property. This is a bindable property.
+        /// </summary>
+        public object ContentFocusedCommandParameter
+        {
+            get => GetValue(ContentFocusedCommandParameterProperty);
+            set => SetValue(ContentFocusedCommandParameterProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the command to invoke when the content is unfocused. This is a bindable property.
+        /// </summary>
+        public ICommand ContentUnfocusedCommand
+        {
+            get => (ICommand)GetValue(ContentUnfocusedCommandProperty);
+            set => SetValue(ContentUnfocusedCommandProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the parameter to pass to the ContentUnfocusedCommand property. This is a bindable property.
+        /// </summary>
+        public object ContentUnfocusedCommandParameter
+        {
+            get => GetValue(ContentUnfocusedCommandParameterProperty);
+            set => SetValue(ContentUnfocusedCommandParameterProperty, value);
         }
 
         /// <summary>
@@ -110,6 +178,16 @@ namespace Tizen.TV.UIControls.Forms
         void OnContentFocused(object sender, FocusEventArgs e)
         {
             OnContentFocused(e.IsFocused);
+            if (e.IsFocused)
+            {
+                ContentFocusedCommand?.Execute(ContentFocusedCommandParameter);
+                ContentFocused?.Invoke(this, e);
+            }
+            else
+            {
+                ContentUnfocusedCommand?.Execute(ContentUnfocusedCommandParameter);
+                ContentUnfocused?.Invoke(this, e);
+            }
         }
 
         void OnDescendantAdded(object sender, ElementEventArgs e)


### PR DESCRIPTION
### Description of Change ###
This PR is update FocusFrame to handle focused event on all descendants view

### Bugs Fixed ###
 None

### API Changes ###
 Added :
``` c#
class FocusFrame {
 public event EventHandler<FocusEventArgs> ContentFocused;
 public event EventHandler<FocusEventArgs> ContentUnfocused;

 public Color UnfocusedColor {get;set;}
 
 public ICommand ContentFocusedCommand {get;set;}
 public object ContentFocusedCommandParameter {get;set;}

 public ICommand ContentUnfocusedCommand {get;set;}
 public object ContentUnfocusedCommandParameter {get;set;}
}
```

### Behavioral Changes ###
 When the focus state of one of the descendant of `Content` changes, `FocusFrame` effect is triggered.

![focusFrame-update1](https://user-images.githubusercontent.com/1029155/99387636-b0ac4a80-2917-11eb-9018-de5470db4c45.gif)
![focusFrame-update2](https://user-images.githubusercontent.com/1029155/99387640-b30ea480-2917-11eb-80ff-138bfca3e9ed.gif)




