### PR TITLE
Fix target file to support theme for all api level

### DIFF
--- a/Tizen.TV.UIControls.targets
+++ b/Tizen.TV.UIControls.targets
@@ -4,7 +4,7 @@
     <ThemeFileDirectory>$(MSBuildThisFileDirectory)..\content\theme\</ThemeFileDirectory>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'tizen40' ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
     <TizenTpkUserIncludeFiles Include="$(ThemeFileDirectory)*.edj">
       <TizenTpkSubDir>res</TizenTpkSubDir>
     </TizenTpkUserIncludeFiles>


### PR DESCRIPTION
### Description of Change ###
This fix allows the theme file (*.edc) to be loaded successfully not only in `tizen40` but also in higher versions (e,g. `tizen60`, `tizen80`,...).


### Bugs Fixed ###
None


### API Changes ###
None

### Behavioral Changes ###
None
