### PR TITLE
Rename Initialize method

### DIFF
--- a/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
+++ b/src/Tizen.TV.UIControls.Forms/RecycleItemsView.cs
@@ -157,7 +157,7 @@ namespace Tizen.TV.UIControls.Forms
         /// </summary>
         public RecycleItemsView()
         {
-            InitializeComponent();
+            Initialize();
         }
 
         /// <summary>
@@ -649,7 +649,7 @@ namespace Tizen.TV.UIControls.Forms
             return false;
         }
 
-        protected void InitializeComponent()
+        protected void Initialize()
         {
             _contentLayout = new ContentLayout(this)
             {


### PR DESCRIPTION
### Description of Change ###

Change the Initialization method name to avoid confusion with the `InitializeComponent` method of xaml.


