### PR TITLE
Supports IsPreviousPageVisible to AnimatedNavigationPage

### DIFF
--- a/sample/Sample/AnimatedNaviPage/AnimatedContentPageTransitTest.cs
+++ b/sample/Sample/AnimatedNaviPage/AnimatedContentPageTransitTest.cs
@@ -103,7 +103,7 @@ namespace Sample
             {
                 var page = new AnimatedContentPage
                 {
-                    BackgroundColor = Color.LightGray,
+                    BackgroundColor = Color.Transparent,
                     PageTranistion = _pageTransition,
                     Content = new StackLayout
                     {
@@ -115,8 +115,8 @@ namespace Sample
                         {
                             new Image
                             {
-                                HeightRequest = 1000,
-                                WidthRequest = 700,
+                                HeightRequest = Device.Idiom == TargetIdiom.TV ? 1000 : 300,
+                                WidthRequest = Device.Idiom == TargetIdiom.TV ? 700 : 200,
                                 Source = "poster/01 Jaws.jpg"
                             },
                         }
@@ -138,8 +138,8 @@ namespace Sample
                 {
                     new Image
                     {
-                        HeightRequest = 1000,
-                        WidthRequest = 700,
+                        HeightRequest = Device.Idiom == TargetIdiom.TV ? 1000 : 300,
+                        WidthRequest = Device.Idiom == TargetIdiom.TV ? 700 : 200,
                         Source = "poster/02 Raiders of the Lost Ark.jpg"
                     },
                     new Label
@@ -200,7 +200,7 @@ namespace Sample
                 }
             };
 
-            this.Content = layout;
+            this.Content = new ScrollView { Content = layout };
         }
     }
 }

--- a/sample/Sample/AnimatedNaviPage/AnimatedNaviMainPage.xaml.cs
+++ b/sample/Sample/AnimatedNaviPage/AnimatedNaviMainPage.xaml.cs
@@ -21,7 +21,8 @@ namespace Sample
             page.BindingContext = model;
             AnimatedNavigationPage naviPage = new AnimatedNavigationPage(page)
             {
-                Title = "Page Transition Test"
+                Title = "Page Transition Test",
+                IsPreviousPageVisible = model.IsPreviousVisible
             };
             await Navigation.PushAsync(naviPage);
         }

--- a/sample/Sample/AnimatedNaviPage/AnimatedNaviPageBasicTest.cs
+++ b/sample/Sample/AnimatedNaviPage/AnimatedNaviPageBasicTest.cs
@@ -13,7 +13,7 @@ namespace Sample
 
         public AnimatedNaviPageBasicTest(int depth)
         {
-            BackgroundColor = depth % 2 == 0 ? Color.LightGray : Color.White;
+            BackgroundColor = depth % 2 == 0 ? Color.Yellow : Color.Transparent;
 
             // Left-Right
             var pushAnim = new Animation {
@@ -138,13 +138,14 @@ namespace Sample
                 {
                     new Image
                     {
-                        HeightRequest = 1000,
-                        WidthRequest = 700,
+                        HeightRequest = Device.Idiom == TargetIdiom.TV ? 1000 : 300,
+                        WidthRequest = Device.Idiom == TargetIdiom.TV ? 700 : 200,
                         Source = _depth % 2 == 0 ? "poster/01 Jaws.jpg" : "poster/02 Raiders of the Lost Ark.jpg"
                     },
                     new Label
                     {
                         Text = "Depth : " + _depth,
+                        TextColor = depth % 2 == 0 ? Color.Black : Device.Idiom == TargetIdiom.TV ? Color.White : Color.Black,
                         HorizontalOptions = LayoutOptions.FillAndExpand,
                         VerticalOptions = LayoutOptions.FillAndExpand,
                     },
@@ -158,7 +159,7 @@ namespace Sample
                 }
             };
 
-            this.Content = layout;
+            this.Content = new ScrollView { Content = layout };
         }
     }
 }

--- a/sample/Sample/AnimatedNaviPage/AnimatedNaviPageTestModel.cs
+++ b/sample/Sample/AnimatedNaviPage/AnimatedNaviPageTestModel.cs
@@ -7,6 +7,7 @@ namespace Sample
     {
         public string Name { get; set; }
         public Type PageType { get; set; }
+        public bool IsPreviousVisible { get; set; }
     }
 
     class AnimatedNaviPageTestModel
@@ -19,12 +20,14 @@ namespace Sample
                 new TestModel
                 {
                     Name = "Basic Test",
-                    PageType = typeof(AnimatedNaviPageBasicTest)
+                    PageType = typeof(AnimatedNaviPageBasicTest),
+                    IsPreviousVisible = true
                 },
                 new TestModel
                 {
                     Name = "Page Trasintion Test",
-                    PageType = typeof(AnimatedContentPageTransitTest)
+                    PageType = typeof(AnimatedContentPageTransitTest),
+                    IsPreviousVisible = false
                 },
             };
         }

--- a/src/Tizen.TV.UIControls.Forms/AnimatedNavigationPage.cs
+++ b/src/Tizen.TV.UIControls.Forms/AnimatedNavigationPage.cs
@@ -24,6 +24,20 @@ namespace Tizen.TV.UIControls.Forms
     public class AnimatedNavigationPage : NavigationPage
     {
         /// <summary>
+        /// Identifies the IsPreviousPageVisible bindable property.
+        /// </summary>
+        public static readonly BindableProperty IsPreviousPageVisibleProperty = BindableProperty.Create("IsPreviousPageVisible", typeof(bool), typeof(AnimatedNavigationPage), default(bool));
+
+        /// <summary>
+        /// Gets ans sets a value that determines whether previous page should be visible or not. This is a bindable property.
+        /// </summary>
+        public bool IsPreviousPageVisible
+        {
+            get { return (bool)GetValue(IsPreviousPageVisibleProperty); }
+            set { SetValue(IsPreviousPageVisibleProperty, value); }
+        }
+
+        /// <summary>
         /// Creates and initializes a new instance of the AnimatedNavigationPage class.
         /// </summary>
         public AnimatedNavigationPage() : base()

--- a/src/Tizen.TV.UIControls.Forms/Renderer/AnimatedNavigationPageRenderer.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/AnimatedNavigationPageRenderer.cs
@@ -78,8 +78,8 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                 navigation.RemovePageRequested += OnRemovePageRequested;
                 navigation.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
                 _previousPage = e.NewElement.CurrentPage;
+                _navigationStack.IsPreviousViewVisible = Element.IsPreviousPageVisible;
             }
-
             base.OnElementChanged(e);
         }
 
@@ -106,6 +106,10 @@ namespace Tizen.TV.UIControls.Forms.Renderer
                     _previousPage = Element.CurrentPage;
                     (_previousPage as IPageController)?.SendAppearing();
                 });
+            }
+            else if (e.PropertyName == AnimatedNavigationPage.IsPreviousPageVisibleProperty.PropertyName)
+            {
+                _navigationStack.IsPreviousViewVisible = Element.IsPreviousPageVisible;
             }
         }
 

--- a/src/Tizen.TV.UIControls.Forms/Renderer/NavigationStack.cs
+++ b/src/Tizen.TV.UIControls.Forms/Renderer/NavigationStack.cs
@@ -25,6 +25,8 @@ namespace Tizen.TV.UIControls.Forms.Renderer
     {
         public IReadOnlyList<EvasObject> Stack => InternalStack;
 
+        public bool IsPreviousViewVisible { get; set; }
+
         List<EvasObject> InternalStack { get; set; }
 
         EvasObject CurrentView { get; set; }
@@ -119,7 +121,8 @@ namespace Tizen.TV.UIControls.Forms.Renderer
         {
             if (CurrentView != InternalStack.LastOrDefault())
             {
-                CurrentView?.Hide();
+                if (!IsPreviousViewVisible)
+                    CurrentView?.Hide();
                 CurrentView = InternalStack.LastOrDefault();
                 CurrentView?.Show();
                 (CurrentView as Widget)?.SetFocus(true);


### PR DESCRIPTION
### Description of Change ###
This PR adds a property (`IsPreviousPageVisible`) for whether to show the existing page or not when adding a page with a transparent background using `AnimatedNavigationPage`.

![anim_nav_p](https://user-images.githubusercontent.com/1029134/108651413-0d199a00-7505-11eb-9d3d-6d05a3905048.gif)

### Bugs Fixed ###
None


### API Changes ###

Added:
 - public bool  AnimatedNavigationPage.IsPreviousPageVisible {get; set;} //Bindable Proerty
 
