### PR TITLE
[CommonUI] Allows Pressed Visual sTate to ContentButton

### DIFF
--- a/sample/Sample/ContentButton/ContentButtonTest.xaml
+++ b/sample/Sample/ContentButton/ContentButtonTest.xaml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:tv="clr-namespace:Tizen.TV.UIControls.Forms;assembly=Tizen.TV.UIControls.Forms"
+             xmlns:cui="clr-namespace:Tizen.Theme.Common;assembly=Tizen.Theme.Common"
              Title="ContentButton Test"
              x:Class="Sample.ContentButton.ContentButtonTest">
     <ContentPage.Content>
         <StackLayout HorizontalOptions="Center">
-            <tv:ContentButton Clicked="ContentButton_Clicked">
+            <cui:ContentButton Clicked="ContentButton_Clicked">
                 <VisualStateManager.VisualStateGroups>
                     <VisualStateGroup x:Name="CommonStates">
                         <VisualState x:Name="Normal">
@@ -19,15 +19,20 @@
                                 <Setter Property="BackgroundColor" Value="Orange"/>
                             </VisualState.Setters>
                         </VisualState>
+                        <VisualState x:Name="Pressed">
+                            <VisualState.Setters>
+                                <Setter Property="BackgroundColor" Value="Red"/>
+                            </VisualState.Setters>
+                        </VisualState>
                     </VisualStateGroup>
                 </VisualStateManager.VisualStateGroups>
                 <Label FontSize="Header" x:Name="_label" Text="Text Button" />
-            </tv:ContentButton>
-            <tv:FocusFrame>
-                <tv:ContentButton Clicked="ContentButton_Clicked_1" HeightRequest="300" WidthRequest="300">
+            </cui:ContentButton>
+            <cui:FocusFrame>
+                <cui:ContentButton Clicked="ContentButton_Clicked_1" HeightRequest="300" WidthRequest="300">
                     <Image x:Name="_image" Source="albumarts/1984, Van Halen.jpg"/>
-                </tv:ContentButton>
-            </tv:FocusFrame>
+                </cui:ContentButton>
+            </cui:FocusFrame>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/src/Tizen.Theme.Common/ContentButton.cs
+++ b/src/Tizen.Theme.Common/ContentButton.cs
@@ -26,6 +26,8 @@ namespace Tizen.Theme.Common
     /// </summary>
     public class ContentButton : ContentView, IButtonController
     {
+        const string PressedVisualState = "Pressed";
+
         /// <summary>
         /// BindableProperty. Identifies the Command bindable property.
         /// </summary>
@@ -37,6 +39,18 @@ namespace Tizen.Theme.Common
         /// </summary>
         public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(ContentButton), null, 
             propertyChanged: (bindable, oldvalue, newvalue) => CommandCanExcuteChanged(bindable, EventArgs.Empty));
+
+        internal static readonly BindablePropertyKey IsPressedPropertyKey = BindableProperty.CreateReadOnly(nameof(IsPressed), typeof(bool), typeof(Button), default(bool));
+
+        /// <summary>
+        /// BindableProperty. Identifies the IsPressed bindable property.
+        /// </summary>
+        public static readonly BindableProperty IsPressedProperty = IsPressedPropertyKey.BindableProperty;
+
+        /// <summary>
+        ///  Gets a value that indicates whether this element is pressed or not.
+        /// </summary>
+        public bool IsPressed => (bool)GetValue(IsPressedProperty);
 
         /// <summary>
         /// Gets or sets command that is executed when the button is clicked.
@@ -97,6 +111,8 @@ namespace Tizen.Theme.Common
         {
             if (IsEnabled)
             {
+                SetIsPressed(true);
+                ChangeVisualState();
                 Pressed?.Invoke(this, EventArgs.Empty);
             }
         }
@@ -109,9 +125,14 @@ namespace Tizen.Theme.Common
         {
             if (IsEnabled)
             {
+                SetIsPressed(false);
+                ChangeVisualState();
                 Released?.Invoke(this, EventArgs.Empty);
             }
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        void SetIsPressed(bool isPressed) => SetValue(IsPressedPropertyKey, isPressed);
 
         protected override void OnBindingContextChanged()
         {
@@ -170,6 +191,18 @@ namespace Tizen.Theme.Common
             if (button.Command != null)
             {
                 button.IsEnabledCore = button.Command.CanExecute(button.CommandParameter);
+            }
+        }
+
+        protected override void ChangeVisualState()
+        {
+            if (IsEnabled && IsPressed)
+            {
+                VisualStateManager.GoToState(this, PressedVisualState);
+            }
+            else
+            {
+                base.ChangeVisualState();
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###
Allows Pressed Visual sTate to ContentButton.

fixes #84

(Normal : Transparent, Focused : Yellow, Pressed : Red)
<img src="https://user-images.githubusercontent.com/1029134/110451128-3c382a00-8107-11eb-9cc0-df3dc3a4d0b5.gif" width=320/>

### Bugs Fixed ###
- None

### API Changes ###
Added:
 - public bool ContentButton.IsPressed // Bindable Property

### Behavioral Changes ###
None
